### PR TITLE
Support RC releases

### DIFF
--- a/go/cmd/cmd.go
+++ b/go/cmd/cmd.go
@@ -100,7 +100,6 @@ func Execute() {
 
 	s.Remote = remote
 	s.ReleaseBranch = releaseBranch
-	s.RC = rcIncrement
 	s.IsLatestRelease = isLatestRelease
 	s.IssueNbGH = issueNb
 	s.IssueLink = issueLink
@@ -108,6 +107,7 @@ func Execute() {
 	if releaseFromIssue == "" {
 		s.Release = release
 	}
+	s.Issue.RC = rcIncrement
 
 	// We only require the release date if the release issue does not exist on GH
 	// If the issue already exist we ignore the flag, the value will be loaded from the Issue

--- a/go/cmd/cmd.go
+++ b/go/cmd/cmd.go
@@ -90,7 +90,7 @@ func Execute() {
 
 	remote := git.FindRemoteName(s.VitessRepo)
 	release, releaseBranch, isLatestRelease := releaser.FindNextRelease(remote, s.MajorRelease)
-	issueNb, issueLink, releaseFromIssue := github.GetReleaseIssueInfo(s.VitessRepo, s.MajorRelease)
+	issueNb, issueLink, releaseFromIssue := github.GetReleaseIssueInfo(s.VitessRepo, s.MajorRelease, rcIncrement)
 
 	// if we want to do an RC-1 release and the branch is different from `main`, something is wrong
 	// and if we want to do an >= RC-2 release, the release as to be the latest AKA on the latest release branch

--- a/go/cmd/cmd.go
+++ b/go/cmd/cmd.go
@@ -89,13 +89,13 @@ func Execute() {
 	git.CorrectCleanRepo(s.VitessRepo)
 
 	remote := git.FindRemoteName(s.VitessRepo)
-	release, releaseBranch, isLatestRelease := releaser.FindNextRelease(remote, s.MajorRelease)
+	release, releaseBranch, isLatestRelease, isFromMain := releaser.FindNextRelease(remote, s.MajorRelease)
 	issueNb, issueLink, releaseFromIssue := github.GetReleaseIssueInfo(s.VitessRepo, s.MajorRelease, rcIncrement)
 
 	// if we want to do an RC-1 release and the branch is different from `main`, something is wrong
 	// and if we want to do an >= RC-2 release, the release as to be the latest AKA on the latest release branch
-	if rcIncrement == 1 && releaseBranch != "main" || rcIncrement >= 2 && !isLatestRelease {
-		log.Fatalf("wanted: RC %d but release branch was %s and latest release was %v", rcIncrement, releaseBranch, isLatestRelease)
+	if rcIncrement == 1 && !isFromMain || rcIncrement >= 2 && !isLatestRelease {
+		log.Fatalf("wanted: RC %d but release branch was %s, latest release was %v and is from main is %v", rcIncrement, releaseBranch, isLatestRelease, isFromMain)
 	}
 
 	s.Remote = remote

--- a/go/cmd/flags/flags.go
+++ b/go/cmd/flags/flags.go
@@ -19,5 +19,6 @@ package flags
 const (
 	MajorRelease = "release"
 	ReleaseDate  = "date"
+	RCIncrement  = "rc"
 	RunLive      = "live"
 )

--- a/go/interactive/main_menu.go
+++ b/go/interactive/main_menu.go
@@ -46,6 +46,7 @@ func MainScreen(ctx context.Context) {
 		ctx,
 		"Pre Release",
 		pre_release.CodeFreezeMenuItem(ctx),
+		pre_release.CopyBranchProtectionRulesMenuItem(ctx),
 		pre_release.UpdateSnapshotOnMainMenuItem(ctx),
 		pre_release.CreateReleasePRMenuItem(ctx),
 		pre_release.CreateMilestoneMenuItem(ctx),

--- a/go/interactive/main_menu.go
+++ b/go/interactive/main_menu.go
@@ -46,6 +46,7 @@ func MainScreen(ctx context.Context) {
 		ctx,
 		"Pre Release",
 		pre_release.CodeFreezeMenuItem(ctx),
+		pre_release.UpdateSnapshotOnMainMenuItem(ctx),
 		pre_release.CreateReleasePRMenuItem(ctx),
 		pre_release.CreateMilestoneMenuItem(ctx),
 	)

--- a/go/interactive/pre_release/copy_branch_protection_rules.go
+++ b/go/interactive/pre_release/copy_branch_protection_rules.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pre_release
+
+import (
+	"context"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"vitess.io/vitess-releaser/go/interactive/ui"
+	"vitess.io/vitess-releaser/go/releaser"
+	"vitess.io/vitess-releaser/go/releaser/pre_release"
+	"vitess.io/vitess-releaser/go/releaser/steps"
+)
+
+type copyBranchProtectionRules []string
+
+func CopyBranchProtectionRulesMenuItem(ctx context.Context) *ui.MenuItem {
+	state := releaser.UnwrapState(ctx)
+	return &ui.MenuItem{
+		State:  state,
+		Name:   steps.CopyBranchProtectionRules,
+		IsDone: state.Issue.CopyBranchProtectionRules,
+		Act:    copyBranchProtectionRulesAct,
+		Update: copyBranchProtectionRulesUpdate,
+
+		// We only want to copy branch protection rules during the first RC release.
+		// This is the only moment where we actually create a new release branch.
+		Ignore: state.Issue.RC != 1,
+	}
+}
+
+func copyBranchProtectionRulesUpdate(mi *ui.MenuItem, msg tea.Msg) (*ui.MenuItem, tea.Cmd) {
+	switch msg := msg.(type) {
+	case copyBranchProtectionRules:
+		return mi, ui.PushDialog(&ui.DoneDialog{
+			StepName: mi.Name,
+			Title:    "Copy branch protection rules",
+			Message:  msg,
+			IsDone:   mi.IsDone,
+		})
+	case ui.DoneDialogAction:
+		if string(msg) != mi.Name {
+			return mi, nil
+		}
+		mi.State.Issue.CopyBranchProtectionRules = !mi.State.Issue.CopyBranchProtectionRules
+		mi.IsDone = !mi.IsDone
+		pl, fn := mi.State.UploadIssue()
+		return mi, tea.Batch(func() tea.Msg {
+			fn()
+			return tea.Msg("")
+		}, ui.PushDialog(ui.NewProgressDialog("Updating the Release Issue", pl)))
+	}
+	return mi, nil
+}
+
+func copyBranchProtectionRulesAct(mi *ui.MenuItem) (*ui.MenuItem, tea.Cmd) {
+	return mi, func() tea.Msg {
+		return copyBranchProtectionRules(pre_release.CopyBranchProtectionRules(mi.State))
+	}
+}

--- a/go/interactive/pre_release/create_github_milestones.go
+++ b/go/interactive/pre_release/create_github_milestones.go
@@ -41,6 +41,8 @@ func CreateMilestoneMenuItem(ctx context.Context) *ui.MenuItem {
 		Update: createMilestoneUpdate,
 		Info:   state.Issue.NewGitHubMilestone.URL,
 		IsDone: state.Issue.NewGitHubMilestone.Done,
+		// If we are releasing RC2 or above, we do not want to create a milestone again
+		Ignore: state.Issue.RC >= 2,
 	}
 }
 

--- a/go/interactive/pre_release/update_snapshot.go
+++ b/go/interactive/pre_release/update_snapshot.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pre_release
+
+import (
+	"context"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"vitess.io/vitess-releaser/go/interactive/ui"
+	"vitess.io/vitess-releaser/go/releaser"
+	"vitess.io/vitess-releaser/go/releaser/steps"
+
+	"vitess.io/vitess-releaser/go/releaser/pre_release"
+)
+
+func UpdateSnapshotOnMainMenuItem(ctx context.Context) *ui.MenuItem {
+	state := releaser.UnwrapState(ctx)
+	act := updateSnapshotOnMainAct
+	if state.Issue.UpdateSnapshotOnMain.Done {
+		act = nil
+	}
+	return &ui.MenuItem{
+		State:  state,
+		Name:   steps.UpdateSnapshotOnMain,
+		Act:    act,
+		Update: updateSnapshotOnMainUpdate,
+		Info:   state.Issue.UpdateSnapshotOnMain.URL,
+		IsDone: state.Issue.UpdateSnapshotOnMain.Done,
+
+		// We only want to update the SNAPSHOT version on main if we are doing a first RC release.
+		// For higher RC releases we can assume it was already done during the first release.
+		Ignore: state.Issue.RC != 1,
+	}
+}
+
+type updateSnapshotOnMainUrl string
+
+func updateSnapshotOnMainUpdate(mi *ui.MenuItem, msg tea.Msg) (*ui.MenuItem, tea.Cmd) {
+	_, ok := msg.(updateSnapshotOnMainUrl)
+	if !ok {
+		return mi, nil
+	}
+
+	mi.Info = mi.State.Issue.UpdateSnapshotOnMain.URL
+	mi.IsDone = mi.State.Issue.UpdateSnapshotOnMain.Done
+	return mi, nil
+}
+
+func updateSnapshotOnMainAct(mi *ui.MenuItem) (*ui.MenuItem, tea.Cmd) {
+	pl, update := pre_release.UpdateSnapshotOnMain(mi.State)
+	return mi, tea.Batch(func() tea.Msg {
+		return updateSnapshotOnMainUrl(update())
+	}, ui.PushDialog(ui.NewProgressDialog("Update SNAPSHOT on main", pl)))
+}

--- a/go/interactive/release/close_milestone.go
+++ b/go/interactive/release/close_milestone.go
@@ -39,6 +39,9 @@ func CloseMilestoneItem(ctx context.Context) *ui.MenuItem {
 		Update: closeMilestoneUpdate,
 		Info:   state.Issue.CloseMilestone.URL,
 		IsDone: state.Issue.CloseMilestone.Done,
+
+		// We do not want to close the milestone if this is an RC release
+		Ignore: state.Issue.RC > 0,
 	}
 }
 

--- a/go/interactive/ui/menu.go
+++ b/go/interactive/ui/menu.go
@@ -53,23 +53,29 @@ type (
 
 		previous            *MenuItem
 		DontCountInProgress bool
+
+		Ignore bool
 	}
 )
 
 var columns = []string{"TASK", "STATUS", "INFO"}
 
 func NewMenu(ctx context.Context, title string, items ...*MenuItem) *Menu {
+	var mi []*MenuItem
 	for i, item := range items {
-		if i == 0 {
+		if item.Ignore {
 			continue
 		}
-		item.previous = items[i-1]
+		if i > 0 {
+			item.previous = mi[len(mi)-1]
+		}
+		mi = append(mi, item)
 	}
 	return &Menu{
 		state:   releaser.UnwrapState(ctx),
 		columns: columns,
 		title:   title,
-		Items:   items,
+		Items:   mi,
 	}
 }
 

--- a/go/releaser/ctx.go
+++ b/go/releaser/ctx.go
@@ -44,5 +44,4 @@ type State struct {
 	Issue     Issue
 	IssueLink string
 	IssueNbGH int
-	RC        int
 }

--- a/go/releaser/ctx.go
+++ b/go/releaser/ctx.go
@@ -44,4 +44,5 @@ type State struct {
 	Issue     Issue
 	IssueLink string
 	IssueNbGH int
+	RC        int
 }

--- a/go/releaser/github/issues.go
+++ b/go/releaser/github/issues.go
@@ -81,14 +81,14 @@ func (i *Issue) UpdateBody(repo string) string {
 	return strings.ReplaceAll(stdOut.String(), "\n", "")
 }
 
-func GetIssueBody(repo string, nb int) string {
+func GetIssueTitleAndBody(repo string, nb int) (string, string) {
 	var i Issue
 	stdOut, _, err := gh.Exec(
 		"issue", "view",
 		strconv.Itoa(nb),
 		"--repo", repo,
 		"--json",
-		"body",
+		"title,body",
 	)
 	if err != nil {
 		log.Fatal(err.Error())
@@ -98,7 +98,7 @@ func GetIssueBody(repo string, nb int) string {
 		log.Fatal(err.Error())
 	}
 
-	return i.Body
+	return i.Title, i.Body
 }
 
 func GetReleaseIssue(repo, release string) (string, string) {

--- a/go/releaser/github/issues.go
+++ b/go/releaser/github/issues.go
@@ -101,7 +101,7 @@ func GetIssueTitleAndBody(repo string, nb int) (string, string) {
 	return i.Title, i.Body
 }
 
-func GetReleaseIssue(repo, release string) (string, string) {
+func GetReleaseIssue(repo, release string, rcIncrement int) (string, string) {
 	res, _, err := gh.Exec(
 		"issue", "list",
 		"-l", "Type: Release",
@@ -122,14 +122,19 @@ func GetReleaseIssue(repo, release string) (string, string) {
 		title := issue["title"]
 		prefix := "Release of v"
 		if strings.HasPrefix(title, fmt.Sprintf("%s%s", prefix, release)) {
+			// If we have an RC increment but the title does not match the RC increment we skip this issue
+			if rcIncrement > 0 && !strings.Contains(title, fmt.Sprintf("-RC%d", rcIncrement)) {
+				continue
+			}
+
 			return issue["url"], title[len(prefix):]
 		}
 	}
 	return "", ""
 }
 
-func GetReleaseIssueInfo(repo, majorRelease string) (nb int, url string, release string) {
-	url, release = GetReleaseIssue(repo, majorRelease)
+func GetReleaseIssueInfo(repo, majorRelease string, rcIncrement int) (nb int, url, release string) {
+	url, release = GetReleaseIssue(repo, majorRelease, rcIncrement)
 	if url == "" {
 		// no issue found
 		return 0, "", ""

--- a/go/releaser/issue.go
+++ b/go/releaser/issue.go
@@ -35,6 +35,7 @@ const (
 	stateReadingBackport
 	stateReadingReleaseBlockerIssue
 	stateReadingCodeFreezeItem
+	stateReadingUpdateSnapshotOnMainItem
 	stateReadingCreateReleasePRItem
 	stateReadingNewMilestoneItem
 	stateReadingMergedReleasePRItem
@@ -59,9 +60,10 @@ const (
 	releaseBlockerItem       = "Make sure release blocker Issues are closed, list below."
 
 	// Pre-Release
-	codeFreezeItem      = "Code Freeze."
-	createReleasePRItem = "Create Release PR."
-	newMilestoneItem    = "Create new GitHub Milestone."
+	codeFreezeItem           = "Code Freeze."
+	updateSnapshotOnMainItem = "Update the SNAPSHOT version on main."
+	createReleasePRItem      = "Create Release PR."
+	newMilestoneItem         = "Create new GitHub Milestone."
 
 	// Release
 	mergeReleasePRItem   = "Merge the Release PR."
@@ -104,9 +106,10 @@ type (
 		ReleaseBlocker    ParentOfItems
 
 		// Pre-Release
-		CodeFreeze         ItemWithLink
-		CreateReleasePR    ItemWithLink
-		NewGitHubMilestone ItemWithLink
+		CodeFreeze           ItemWithLink
+		UpdateSnapshotOnMain ItemWithLink
+		CreateReleasePR      ItemWithLink
+		NewGitHubMilestone   ItemWithLink
 
 		// Release
 		MergeReleasePR       ItemWithLink
@@ -151,6 +154,12 @@ const (
 - [{{fmtStatus .CodeFreeze.Done}}] Code Freeze.
 {{- if .CodeFreeze.URL }}
   - {{ .CodeFreeze.URL }}
+{{- end }}
+{{- if gt .RC 0 }}
+- [{{fmtStatus .UpdateSnapshotOnMain.Done}}] Update the SNAPSHOT version on main.
+{{- if .UpdateSnapshotOnMain.URL }}
+  - {{ .UpdateSnapshotOnMain.URL }}
+{{- end }}
 {{- end }}
 - [{{fmtStatus .CreateReleasePR.Done}}] Create Release PR.
 {{- if .CreateReleasePR.URL }}
@@ -277,6 +286,12 @@ func (ctx *State) LoadIssue() {
 					s = stateReadingCodeFreezeItem
 				}
 			}
+			if strings.Contains(line, updateSnapshotOnMainItem) {
+				newIssue.UpdateSnapshotOnMain.Done = strings.HasPrefix(line, markdownItemDone)
+				if isNextLineAList(lines, i) {
+					s = stateReadingUpdateSnapshotOnMainItem
+				}
+			}
 			if strings.Contains(line, createReleasePRItem) {
 				newIssue.CreateReleasePR.Done = strings.HasPrefix(line, markdownItemDone)
 				if isNextLineAList(lines, i) {
@@ -350,6 +365,8 @@ func (ctx *State) LoadIssue() {
 			newIssue.ReleaseBlocker.Items = append(newIssue.ReleaseBlocker.Items, handleNewListItem(lines, i, &s))
 		case stateReadingCodeFreezeItem:
 			newIssue.CodeFreeze.URL = handleSingleTextItem(line, &s)
+		case stateReadingUpdateSnapshotOnMainItem:
+			newIssue.UpdateSnapshotOnMain.URL = handleSingleTextItem(line, &s)
 		case stateReadingCreateReleasePRItem:
 			newIssue.CreateReleasePR.URL = handleSingleTextItem(line, &s)
 		case stateReadingNewMilestoneItem:

--- a/go/releaser/issue.go
+++ b/go/releaser/issue.go
@@ -181,9 +181,11 @@ const (
 {{- end }}
 - [{{fmtStatus .Benchmarked}}] Make sure the release is benchmarked by arewefastyet.
 - [{{fmtStatus .DockerImages}}] Docker Images available on DockerHub.
+{{- if eq .RC 0 }}
 - [{{fmtStatus .CloseMilestone.Done}}] Close current GitHub Milestone.
 {{- if .CloseMilestone.URL }}
   - {{ .CloseMilestone.URL }}
+{{- end }}
 {{- end }}
 
 

--- a/go/releaser/issue.go
+++ b/go/releaser/issue.go
@@ -60,10 +60,11 @@ const (
 	releaseBlockerItem       = "Make sure release blocker Issues are closed, list below."
 
 	// Pre-Release
-	codeFreezeItem           = "Code Freeze."
-	updateSnapshotOnMainItem = "Update the SNAPSHOT version on main."
-	createReleasePRItem      = "Create Release PR."
-	newMilestoneItem         = "Create new GitHub Milestone."
+	codeFreezeItem                = "Code Freeze."
+	copyBranchProtectionRulesItem = "Copy branch protection rules."
+	updateSnapshotOnMainItem      = "Update the SNAPSHOT version on main."
+	createReleasePRItem           = "Create Release PR."
+	newMilestoneItem              = "Create new GitHub Milestone."
 
 	// Release
 	mergeReleasePRItem   = "Merge the Release PR."
@@ -106,10 +107,11 @@ type (
 		ReleaseBlocker    ParentOfItems
 
 		// Pre-Release
-		CodeFreeze           ItemWithLink
-		UpdateSnapshotOnMain ItemWithLink
-		CreateReleasePR      ItemWithLink
-		NewGitHubMilestone   ItemWithLink
+		CodeFreeze                ItemWithLink
+		CopyBranchProtectionRules bool
+		UpdateSnapshotOnMain      ItemWithLink
+		CreateReleasePR           ItemWithLink
+		NewGitHubMilestone        ItemWithLink
 
 		// Release
 		MergeReleasePR       ItemWithLink
@@ -155,7 +157,8 @@ const (
 {{- if .CodeFreeze.URL }}
   - {{ .CodeFreeze.URL }}
 {{- end }}
-{{- if gt .RC 0 }}
+{{- if eq .RC 1 }}
+- [{{fmtStatus .CopyBranchProtectionRules}}] Copy branch protection rules.
 - [{{fmtStatus .UpdateSnapshotOnMain.Done}}] Update the SNAPSHOT version on main.
 {{- if .UpdateSnapshotOnMain.URL }}
   - {{ .UpdateSnapshotOnMain.URL }}
@@ -285,6 +288,9 @@ func (ctx *State) LoadIssue() {
 				if isNextLineAList(lines, i) {
 					s = stateReadingCodeFreezeItem
 				}
+			}
+			if strings.Contains(line, copyBranchProtectionRulesItem) {
+				newIssue.CopyBranchProtectionRules = strings.HasPrefix(line, markdownItemDone)
 			}
 			if strings.Contains(line, updateSnapshotOnMainItem) {
 				newIssue.UpdateSnapshotOnMain.Done = strings.HasPrefix(line, markdownItemDone)

--- a/go/releaser/issue.go
+++ b/go/releaser/issue.go
@@ -132,7 +132,11 @@ const (
 
 - [{{fmtStatus .SlackPreRequisite}}] Notify the community on Slack.
 - [{{fmtStatus .CheckSummary}}] Make sure the release notes summary is prepared and clean.
+{{- if eq .RC 0 }}
 - Make sure backport Pull Requests are merged, list below.
+{{- else }}
+- Make sure important Pull Requests are merged, list below.
+{{- end }}
 {{- range $item := .CheckBackport.Items }}
   - [{{fmtStatus $item.Done}}] {{$item.URL}}
 {{- end }}

--- a/go/releaser/issue.go
+++ b/go/releaser/issue.go
@@ -419,8 +419,8 @@ func CreateReleaseIssue(state *State) (*logging.ProgressLogging, func() (int, st
 	return pl, func() (int, string) {
 		pl.NewStepf("Create Release Issue on GitHub")
 		issueTitle := fmt.Sprintf("Release of v%s", state.Release)
-		if state.RC > 0 {
-			issueTitle = fmt.Sprintf("%s-RC%d", issueTitle, state.RC)
+		if state.Issue.RC > 0 {
+			issueTitle = fmt.Sprintf("%s-RC%d", issueTitle, state.Issue.RC)
 		}
 		newIssue := github.Issue{
 			Title:    issueTitle,
@@ -476,4 +476,8 @@ func CloseReleaseIssue(state *State) (*logging.ProgressLogging, func() string) {
 		pl.NewStepf("Issue updated, see: %s", issueLink)
 		return state.IssueLink
 	}
+}
+
+func RemoveRCFromReleaseTitle(release string) string {
+	return release[:strings.Index(release, "-RC")]
 }

--- a/go/releaser/issue.go
+++ b/go/releaser/issue.go
@@ -156,9 +156,11 @@ const (
 {{- if .CreateReleasePR.URL }}
   - {{ .CreateReleasePR.URL }}
 {{- end }}
+{{- if lt .RC 2 }}
 - [{{fmtStatus .NewGitHubMilestone.Done}}] Create new GitHub Milestone.
 {{- if .NewGitHubMilestone.URL }}
   - {{ .NewGitHubMilestone.URL }}
+{{- end }}
 {{- end }}
 
 ### Release

--- a/go/releaser/milestone.go
+++ b/go/releaser/milestone.go
@@ -24,14 +24,9 @@ import (
 )
 
 func FindVersionAfterNextRelease(state *State) string {
-	segments := strings.Split(state.Release, ".")
+	segments := strings.Split(RemoveRCFromReleaseTitle(state.Release), ".")
 	if len(segments) != 3 {
 		return ""
-	}
-
-	// Remove the -RCX token from the last segment of the release name
-	if strings.Contains(segments[2], "-RC") {
-		segments[2] = segments[2][:strings.Index(segments[2], "-RC")]
 	}
 
 	segmentInts := make([]int, 0, len(segments))

--- a/go/releaser/milestone.go
+++ b/go/releaser/milestone.go
@@ -24,13 +24,14 @@ import (
 )
 
 func FindVersionAfterNextRelease(state *State) string {
-	if strings.Contains(state.Release, "rc") {
-		panic("RC releases not supported for now")
-	}
-
 	segments := strings.Split(state.Release, ".")
 	if len(segments) != 3 {
 		return ""
+	}
+
+	// Remove the -RCX token from the last segment of the release name
+	if strings.Contains(segments[2], "-RC") {
+		segments[2] = segments[2][:strings.Index(segments[2], "-RC")]
 	}
 
 	segmentInts := make([]int, 0, len(segments))
@@ -42,7 +43,7 @@ func FindVersionAfterNextRelease(state *State) string {
 		segmentInts = append(segmentInts, v)
 	}
 
-	// if it is a major release
+	// if it is an RC/GA release
 	if segmentInts[1] == 0 && segmentInts[2] == 0 {
 		return fmt.Sprintf("%d.0.0", segmentInts[0]+1)
 	}

--- a/go/releaser/pre_release/code_freeze.go
+++ b/go/releaser/pre_release/code_freeze.go
@@ -75,7 +75,7 @@ func CodeFreeze(state *releaser.State) (*logging.ProgressLogging, func() string)
 			pl.NewStepf("Issue updated, see: %s", issueLink)
 		}()
 
-		if state.RC == 1 {
+		if state.Issue.RC == 1 {
 			pl.NewStepf("Fetch from git remote and create branch %s", state.ReleaseBranch)
 		} else {
 			pl.NewStepf("Fetch from git remote")
@@ -83,7 +83,7 @@ func CodeFreeze(state *releaser.State) (*logging.ProgressLogging, func() string)
 
 		git.CorrectCleanRepo(state.VitessRepo)
 
-		if state.RC == 1 {
+		if state.Issue.RC == 1 {
 			git.ResetHard(state.Remote, "main")
 			if err := git.CreateBranchAndCheckout(state.ReleaseBranch, fmt.Sprintf("%s/main", state.Remote)); err != nil {
 				git.Checkout(state.ReleaseBranch)

--- a/go/releaser/pre_release/code_freeze.go
+++ b/go/releaser/pre_release/code_freeze.go
@@ -75,9 +75,24 @@ func CodeFreeze(state *releaser.State) (*logging.ProgressLogging, func() string)
 			pl.NewStepf("Issue updated, see: %s", issueLink)
 		}()
 
-		pl.NewStepf("Fetch from git remote")
+		if state.RC == 1 {
+			pl.NewStepf("Fetch from git remote and create branch %s", state.ReleaseBranch)
+		} else {
+			pl.NewStepf("Fetch from git remote")
+		}
+
 		git.CorrectCleanRepo(state.VitessRepo)
-		git.ResetHard(state.Remote, state.ReleaseBranch)
+
+		if state.RC == 1 {
+			git.ResetHard(state.Remote, "main")
+			if err := git.CreateBranchAndCheckout(state.ReleaseBranch, fmt.Sprintf("%s/main", state.Remote)); err != nil {
+				git.Checkout(state.ReleaseBranch)
+			} else {
+				git.Push(state.Remote, state.ReleaseBranch)
+			}
+		} else {
+			git.ResetHard(state.Remote, state.ReleaseBranch)
+		}
 
 		codeFreezePRName := fmt.Sprintf("[%s] Code Freeze for `v%s`", state.ReleaseBranch, state.Release)
 

--- a/go/releaser/pre_release/code_freeze.go
+++ b/go/releaser/pre_release/code_freeze.go
@@ -48,7 +48,7 @@ func CodeFreeze(state *releaser.State) (*logging.ProgressLogging, func() string)
 	}
 
 	waitForPRToBeMerged := func(nb int) {
-		pl.NewStepf("Waiting for the PR to be merged. You must enable bypassing the branch protection rules in: https://github.com/vitessio/vitess/settings/branches")
+		pl.NewStepf("Waiting for the PR to be merged. You must enable bypassing the branch protection rules in: https://github.com/%s/settings/branches", state.VitessRepo)
 	outer:
 		for {
 			select {

--- a/go/releaser/pre_release/copy_branch_protection_rules.go
+++ b/go/releaser/pre_release/copy_branch_protection_rules.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pre_release
+
+import (
+	"fmt"
+
+	"vitess.io/vitess-releaser/go/releaser"
+)
+
+func CopyBranchProtectionRules(state *releaser.State) []string {
+	return []string{
+		fmt.Sprintf("Since we have created the new branch %s, we need to copy the branch protection rules from main into %s", state.ReleaseBranch, state.ReleaseBranch),
+		fmt.Sprintf("To do this, head over to https://github.com/%s/settings/branches and create a new rule for branch %s", state.VitessRepo, state.ReleaseBranch),
+	}
+}

--- a/go/releaser/pre_release/create_release_pr.go
+++ b/go/releaser/pre_release/create_release_pr.go
@@ -112,10 +112,8 @@ func CreateReleasePR(state *releaser.State) (*logging.ProgressLogging, func() st
 			git.Push(state.Remote, newBranchName)
 		}
 
-		releaseWithNoRC := releaser.RemoveRCFromReleaseTitle(state.Release)
-
 		pl.NewStepf("Generate the release notes")
-		generateReleaseNotes(state, releaseWithNoRC)
+		generateReleaseNotes(state, releaser.RemoveRCFromReleaseTitle(state.Release))
 
 		pl.NewStepf("Commit the release notes")
 		if !git.CommitAll("Addition of release notes") {
@@ -123,14 +121,15 @@ func CreateReleasePR(state *releaser.State) (*logging.ProgressLogging, func() st
 			git.Push(state.Remote, newBranchName)
 		}
 
+		lowerRelease := strings.ToLower(state.Release)
 		pl.NewStepf("Update the code examples")
-		updateExamples(strings.ToLower(state.Release), "") // TODO: vitess-operator version not implemented
+		updateExamples(lowerRelease, "") // TODO: vitess-operator version not implemented
 
 		pl.NewStepf("Update version.go")
-		UpdateVersionGoFile(releaseWithNoRC)
+		UpdateVersionGoFile(lowerRelease)
 
 		pl.NewStepf("Update the Java directory")
-		UpdateJavaDir(releaseWithNoRC)
+		UpdateJavaDir(lowerRelease)
 
 		pl.NewStepf("Commit the update to the codebase for the v%s release", state.Release)
 		if !git.CommitAll(fmt.Sprintf("Update codebase for the v%s release", state.Release)) {

--- a/go/releaser/pre_release/create_release_pr.go
+++ b/go/releaser/pre_release/create_release_pr.go
@@ -112,8 +112,10 @@ func CreateReleasePR(state *releaser.State) (*logging.ProgressLogging, func() st
 			git.Push(state.Remote, newBranchName)
 		}
 
+		releaseWithNoRC := releaser.RemoveRCFromReleaseTitle(state.Release)
+
 		pl.NewStepf("Generate the release notes")
-		generateReleaseNotes(state, state.Release)
+		generateReleaseNotes(state, releaseWithNoRC)
 
 		pl.NewStepf("Commit the release notes")
 		if !git.CommitAll("Addition of release notes") {
@@ -122,13 +124,13 @@ func CreateReleasePR(state *releaser.State) (*logging.ProgressLogging, func() st
 		}
 
 		pl.NewStepf("Update the code examples")
-		updateExamples(state.Release, "") // TODO: vitess-operator version not implemented
+		updateExamples(strings.ToLower(state.Release), "") // TODO: vitess-operator version not implemented
 
 		pl.NewStepf("Update version.go")
-		UpdateVersionGoFile(state.Release)
+		UpdateVersionGoFile(releaseWithNoRC)
 
 		pl.NewStepf("Update the Java directory")
-		UpdateJavaDir(state.Release)
+		UpdateJavaDir(releaseWithNoRC)
 
 		pl.NewStepf("Commit the update to the codebase for the v%s release", state.Release)
 		if !git.CommitAll(fmt.Sprintf("Update codebase for the v%s release", state.Release)) {

--- a/go/releaser/pre_release/release_notes.go
+++ b/go/releaser/pre_release/release_notes.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"path"
 	"regexp"
 	"sort"
@@ -182,6 +183,13 @@ Thanks to all our contributors: @%s
 	}
 
 	releaseNotes.generate()
+
+	// update the entire changelog directory
+	// go run ./go/tools/releases/releases.go
+	out, err := exec.Command("go", "run", "./go/tools/releases/releases.go").CombinedOutput()
+	if err != nil {
+		log.Fatalf("%s: %s", err, out)
+	}
 }
 
 func (rn *releaseNote) generate() {

--- a/go/releaser/pre_release/update_snapshot.go
+++ b/go/releaser/pre_release/update_snapshot.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pre_release
+
+import (
+	"fmt"
+
+	"vitess.io/vitess-releaser/go/releaser"
+	"vitess.io/vitess-releaser/go/releaser/git"
+	"vitess.io/vitess-releaser/go/releaser/github"
+	"vitess.io/vitess-releaser/go/releaser/logging"
+)
+
+func UpdateSnapshotOnMain(state *releaser.State) (*logging.ProgressLogging, func() string) {
+	pl := &logging.ProgressLogging{
+		TotalSteps: 10,
+	}
+
+	var done bool
+	var url string
+	return pl, func() string {
+		defer func() {
+			state.Issue.UpdateSnapshotOnMain.Done = done
+			state.Issue.UpdateSnapshotOnMain.URL = url
+			pl.NewStepf("Update Issue %s on GitHub", state.IssueLink)
+			_, fn := state.UploadIssue()
+			issueLink := fn()
+
+			pl.NewStepf("Issue updated, see: %s", issueLink)
+		}()
+
+		pl.NewStepf("Fetch from git remote")
+		git.CorrectCleanRepo(state.VitessRepo)
+		git.Checkout("main")
+		git.ResetHard(state.Remote, "main")
+
+		nextNextRelease := releaser.FindVersionAfterNextRelease(state)
+		snapshotRelease := fmt.Sprintf("%s-SNAPSHOT", nextNextRelease)
+
+		snapshotUpdatePRName := fmt.Sprintf("Bump to `v%s` after the `v%s` release", snapshotRelease, state.Release)
+
+		// look for existing PRs
+		pl.NewStepf("Look for an existing Pull Request named '%s'", snapshotUpdatePRName)
+		if _, url = github.FindPR(state.VitessRepo, snapshotUpdatePRName); url != "" {
+			pl.TotalSteps = 5 // only 5 total steps in this situation
+			pl.NewStepf("An opened Pull Request was found: %s", url)
+			done = true
+			return url
+		}
+
+		pl.NewStepf("Create new branch based on %s/%s", state.Remote, "main")
+		newBranchName := git.FindNewGeneratedBranch(state.Remote, "main", "snapshot-update")
+
+		pl.NewStepf("Update version.go")
+		UpdateVersionGoFile(snapshotRelease)
+
+		pl.NewStepf("Update the Java directory")
+		UpdateJavaDir(snapshotRelease)
+
+		pl.NewStepf("Commit and push to branch %s", newBranchName)
+		if git.CommitAll(fmt.Sprintf("Snapshot update: %s", snapshotUpdatePRName)) {
+			pl.TotalSteps = 9 // only 9 total steps in this situation
+			pl.NewStepf("Nothing to commit, seems like back to dev mode is already done")
+			done = true
+			return ""
+		}
+		git.Push(state.Remote, newBranchName)
+
+		pl.NewStepf("Create Pull Request")
+		pr := github.PR{
+			Title:  snapshotUpdatePRName,
+			Body:   fmt.Sprintf("Includes the changes required to update the SNAPSHOT version (v%s) after the release of v%s.", snapshotRelease, state.Release),
+			Branch: newBranchName,
+			Base:   "main",
+			Labels: []github.Label{{Name: "Component: General"}, {Name: "Type: Release"}},
+		}
+		_, url = pr.Create(state.VitessRepo)
+		pl.NewStepf("Pull Request created %s", url)
+		done = true
+		return ""
+	}
+}

--- a/go/releaser/prerequisite/summary.go
+++ b/go/releaser/prerequisite/summary.go
@@ -25,7 +25,7 @@ import (
 func CheckSummary(state *releaser.State) []string {
 	return []string{
 		"If the release does not contain significant changes (i.e. a small patch release) then this step can be skipped",
-		fmt.Sprintf("The summary file is located in: ./changelog/%s.0/%s/summary.md.", state.MajorRelease, state.Release),
+		fmt.Sprintf("The summary file is located in: ./changelog/%s.0/%s/summary.md.", state.MajorRelease, releaser.RemoveRCFromReleaseTitle(state.Release)),
 		"The summary file for a release candidate is the same as the one for the GA release.",
 	}
 }

--- a/go/releaser/release/back_to_dev.go
+++ b/go/releaser/release/back_to_dev.go
@@ -48,7 +48,15 @@ func BackToDevMode(state *releaser.State) (*logging.ProgressLogging, func() stri
 		git.CorrectCleanRepo(state.VitessRepo)
 		git.ResetHard(state.Remote, state.ReleaseBranch)
 
-		nextNextRelease := releaser.FindVersionAfterNextRelease(state)
+		// If we are releasing an RC release, the next SNAPSHOT version on the release branch
+		// will be the same release as the RC but without the RC tag.
+		var nextNextRelease string
+		if state.Issue.RC > 0 {
+			nextNextRelease = releaser.RemoveRCFromReleaseTitle(state.Release)
+		} else {
+			nextNextRelease = releaser.FindVersionAfterNextRelease(state)
+		}
+
 		devModeRelease := fmt.Sprintf("%s-SNAPSHOT", nextNextRelease)
 
 		backToDevModePRName := fmt.Sprintf("[%s] Bump to `v%s` after the `v%s` release", state.ReleaseBranch, devModeRelease, state.Release)

--- a/go/releaser/release/release_notes_on_main.go
+++ b/go/releaser/release/release_notes_on_main.go
@@ -65,7 +65,7 @@ func ReleaseNotesOnMain(state *releaser.State) (*logging.ProgressLogging, func()
 		newBranchName := git.FindNewGeneratedBranch(state.Remote, "main", "release-notes-main")
 
 		pl.NewStepf("Copy release notes from %s/%s", state.Remote, state.ReleaseBranch)
-		releaseNotesPath := pre_release.GetReleaseNotesDirPathForMajor(state.Release)
+		releaseNotesPath := pre_release.GetReleaseNotesDirPathForMajor(releaser.RemoveRCFromReleaseTitle(state.Release))
 		git.CheckoutPath(state.Remote, state.ReleaseBranch, releaseNotesPath)
 
 		pl.NewStepf("Commit and push to branch %s", newBranchName)

--- a/go/releaser/release/tag_release.go
+++ b/go/releaser/release/tag_release.go
@@ -39,19 +39,25 @@ func TagRelease(state *releaser.State) (*logging.ProgressLogging, func() string)
 		git.CorrectCleanRepo(state.VitessRepo)
 		git.ResetHard(state.Remote, state.ReleaseBranch)
 
+		// We want to transform the release name into lower case in case the release is an RC
+		// Example: we will go from v19.0.0-RC1 to v19.0.0-rc1 which is a better format for our tags
+		lowerCaseRelease := strings.ToLower(state.Release)
+
 		pl.NewStepf("Create and push the tags")
-		gitTag := fmt.Sprintf("v%s", state.Release)
+		gitTag := fmt.Sprintf("v%s", lowerCaseRelease)
 		git.TagAndPush(state.Remote, gitTag)
+
 		// we also need to tag and push the Go doc tag
 		// i.e. if we release v17.0.1, we also want to tag: v0.17.1
-		nextReleaseSplit := strings.Split(state.Release, ".")
+		nextReleaseSplit := strings.Split(lowerCaseRelease, ".")
 		if len(nextReleaseSplit) != 3 {
 			log.Fatalf("%s was not formated x.x.x", state.Release)
 		}
-		git.TagAndPush(state.Remote, fmt.Sprintf("v0.%s.%s", nextReleaseSplit[0], nextReleaseSplit[2]))
+		gdocGitTag := fmt.Sprintf("v0.%s.%s", nextReleaseSplit[0], nextReleaseSplit[2])
+		git.TagAndPush(state.Remote, gdocGitTag)
 
 		pl.NewStepf("Create the release on the GitHub UI")
-		releaseNotesPath := path.Join(pre_release.GetReleaseNotesDirPath(state.Release), "release_notes.md")
+		releaseNotesPath := path.Join(pre_release.GetReleaseNotesDirPath(releaser.RemoveRCFromReleaseTitle(state.Release)), "release_notes.md")
 		url := github.CreateRelease(state.VitessRepo, gitTag, releaseNotesPath, state.IsLatestRelease)
 
 		pl.NewStepf("Done %s", url)

--- a/go/releaser/slack/slack.go
+++ b/go/releaser/slack/slack.go
@@ -18,13 +18,14 @@ package slack
 
 import (
 	"fmt"
+	"strings"
 
 	"vitess.io/vitess-releaser/go/releaser"
 )
 
 const (
 	preRequisiteSlackMessage = `📣 The Vitess maintainers are planning on releasing v%s on %s.`
-	postReleaseSlackMessage  = `📣 We have just released v%s. Check out the release notes on https://github.com/%s/release/tag/v%s`
+	postReleaseSlackMessage  = `📣 We have just released v%s. Check out the release notes on https://github.com/%s/releases/tag/v%s`
 )
 
 func AnnouncementMessage(state *releaser.State) string {
@@ -32,5 +33,5 @@ func AnnouncementMessage(state *releaser.State) string {
 }
 
 func PostReleaseMessage(state *releaser.State) string {
-	return fmt.Sprintf(postReleaseSlackMessage, state.Release, state.VitessRepo, state.Release)
+	return fmt.Sprintf(postReleaseSlackMessage, state.Release, state.VitessRepo, strings.ToLower(state.Release))
 }

--- a/go/releaser/steps/steps.go
+++ b/go/releaser/steps/steps.go
@@ -26,10 +26,11 @@ const (
 	CheckSummary      = "Check Release Summary"
 
 	// Pre-Release
-	CodeFreeze           = "Code Freeze"
-	UpdateSnapshotOnMain = "Update SNAPSHOT on main"
-	CreateReleasePR      = "Create Release PR"
-	CreateMilestone      = "Create Milestone"
+	CodeFreeze                = "Code Freeze"
+	CopyBranchProtectionRules = "Copy branch protection rules"
+	UpdateSnapshotOnMain      = "Update SNAPSHOT on main"
+	CreateReleasePR           = "Create Release PR"
+	CreateMilestone           = "Create Milestone"
 
 	// Release
 	MergeReleasePR       = "Merge Release PR"

--- a/go/releaser/steps/steps.go
+++ b/go/releaser/steps/steps.go
@@ -26,9 +26,10 @@ const (
 	CheckSummary      = "Check Release Summary"
 
 	// Pre-Release
-	CodeFreeze      = "Code Freeze"
-	CreateReleasePR = "Create Release PR"
-	CreateMilestone = "Create Milestone"
+	CodeFreeze           = "Code Freeze"
+	UpdateSnapshotOnMain = "Update SNAPSHOT on main"
+	CreateReleasePR      = "Create Release PR"
+	CreateMilestone      = "Create Milestone"
 
 	// Release
 	MergeReleasePR       = "Merge Release PR"


### PR DESCRIPTION
This PR adds supports for RC releases. A new flag is added: `--rc=x` with `x` being the increment of the RC release you'd like to release.