### PR TITLE
Replace all logs.Fatal by logs.Panic

### DIFF
--- a/go/cmd/cmd.go
+++ b/go/cmd/cmd.go
@@ -116,7 +116,7 @@ func setUpVitessReleaseInformation(s *releaser.State, repo string) (releaser.Rel
 	// if we want to do an RC-1 release and the branch is different from `main`, something is wrong
 	// and if we want to do an >= RC-2 release, the release as to be the latest AKA on the latest release branch
 	if rcIncrement >= 1 && !isLatestRelease {
-		log.Fatalf("wanted: RC %d but release branch was %s, latest release was %v and is from main is %v", rcIncrement, releaseBranch, isLatestRelease, isFromMain)
+		log.Panicf("wanted: RC %d but release branch was %s, latest release was %v and is from main is %v", rcIncrement, releaseBranch, isLatestRelease, isFromMain)
 	}
 
 	vitessRelease := releaser.ReleaseInformation{

--- a/go/releaser/git/git.go
+++ b/go/releaser/git/git.go
@@ -32,7 +32,7 @@ var (
 func checkCurrentRepo(repoWanted string) bool {
 	out, err := exec.Command("git", "remote", "-v").CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 	outStr := string(out)
 	return strings.Contains(outStr, repoWanted)
@@ -41,7 +41,7 @@ func checkCurrentRepo(repoWanted string) bool {
 func cleanLocalState() bool {
 	out, err := exec.Command("git", "status", "-s").CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 	return len(out) == 0
 }
@@ -49,26 +49,26 @@ func cleanLocalState() bool {
 func Checkout(branch string) {
 	out, err := exec.Command("git", "checkout", branch).CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 }
 
 func Pull(remote, branch string) {
 	out, err := exec.Command("git", "pull", remote, branch).CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 }
 
 func ResetHard(remote, branch string) {
 	out, err := exec.Command("git", "fetch", remote).CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 
 	out, err = exec.Command("git", "reset", "--hard", remote+"/"+branch).CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 }
 
@@ -78,7 +78,7 @@ func CreateBranchAndCheckout(branch, base string) error {
 		if strings.Contains(string(out), fmt.Sprintf("a branch named '%s' already exists", branch)) {
 			return errBranchExists
 		}
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 	return nil
 }
@@ -86,14 +86,14 @@ func CreateBranchAndCheckout(branch, base string) error {
 func Push(remote, branch string) {
 	out, err := exec.Command("git", "push", remote, branch).CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 }
 
 func CommitAll(msg string) (empty bool) {
 	out, err := exec.Command("git", "add", "--all").CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 
 	out, err = exec.Command("git", "commit", "-n", "-s", "-m", msg).CombinedOutput()
@@ -101,7 +101,7 @@ func CommitAll(msg string) (empty bool) {
 		if strings.Contains(string(out), "nothing to commit, working tree clean") {
 			return true
 		}
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 	return false
 }
@@ -112,7 +112,7 @@ func CommitAll(msg string) (empty bool) {
 func FindRemoteName(repository string) string {
 	out, err := exec.Command("git", "remote", "-v").CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 	gitRemoteOutput := string(out)
 
@@ -131,17 +131,17 @@ func FindRemoteName(repository string) string {
 
 func CorrectCleanRepo(repo string) {
 	if !checkCurrentRepo(repo + ".git") {
-		log.Fatalf("failed to find remote %s in %s", repo, getWorkingDir())
+		log.Panicf("failed to find remote %s in %s", repo, getWorkingDir())
 	}
 	if !cleanLocalState() {
-		log.Fatalf("the %s repository should have a clean state", getWorkingDir())
+		log.Panicf("the %s repository should have a clean state", getWorkingDir())
 	}
 }
 
 func getWorkingDir() string {
 	dir, err := os.Getwd()
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 	return dir
 }
@@ -157,7 +157,7 @@ func FindNewGeneratedBranch(remote, baseBranch, branchName string) string {
 			if errors.Is(err, errBranchExists) {
 				continue
 			}
-			log.Fatal(err)
+			log.Panic(err)
 		}
 		break
 	}
@@ -170,12 +170,12 @@ func TagAndPush(remote, tag string) (exists bool) {
 		if strings.Contains(string(out), "already exists") {
 			return true
 		}
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 
 	out, err = exec.Command("git", "push", remote, tag).CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 	return false
 }
@@ -183,7 +183,7 @@ func TagAndPush(remote, tag string) (exists bool) {
 func GetSHAForGitRef(ref string) string {
 	out, err := exec.Command("git", "rev-parse", ref).CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 	return strings.ReplaceAll(string(out), "\n", "")
 }
@@ -191,6 +191,6 @@ func GetSHAForGitRef(ref string) string {
 func CheckoutPath(remote, branch, path string) {
 	out, err := exec.Command("git", "checkout", fmt.Sprintf("%s/%s", remote, branch), path).CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 }

--- a/go/releaser/github/issues.go
+++ b/go/releaser/github/issues.go
@@ -45,7 +45,7 @@ func CloseReleaseIssue(repo string, nb int) {
 		"--comment", fmt.Sprintf("Release completed."),
 	)
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 }
 
@@ -64,7 +64,7 @@ func (i *Issue) Create(repo string) string {
 		"--assignee", i.Assignee,
 	)
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 	return strings.ReplaceAll(stdOut.String(), "\n", "")
 }
@@ -76,7 +76,7 @@ func (i *Issue) UpdateBody(repo string) string {
 		strconv.Itoa(i.Number), "-b", i.Body,
 	)
 	if err != nil {
-		log.Fatal(err.Error())
+		log.Panic(err.Error())
 	}
 	return strings.ReplaceAll(stdOut.String(), "\n", "")
 }
@@ -91,11 +91,11 @@ func GetIssueTitleAndBody(repo string, nb int) (string, string) {
 		"title,body",
 	)
 	if err != nil {
-		log.Fatal(err.Error())
+		log.Panic(err.Error())
 	}
 	err = json.Unmarshal(stdOut.Bytes(), &i)
 	if err != nil {
-		log.Fatal(err.Error())
+		log.Panic(err.Error())
 	}
 
 	return i.Title, i.Body
@@ -109,13 +109,13 @@ func GetReleaseIssue(repo, release string, rcIncrement int) (string, string) {
 		"--repo", repo,
 	)
 	if err != nil {
-		log.Fatal(err.Error())
+		log.Panic(err.Error())
 	}
 
 	var issues []map[string]string
 	err = json.Unmarshal(res.Bytes(), &issues)
 	if err != nil {
-		log.Fatal(err.Error())
+		log.Panic(err.Error())
 	}
 
 	for _, issue := range issues {
@@ -148,7 +148,7 @@ func URLToNb(url string) int {
 	issueNbStr := url[lastIdx+1:]
 	nb, err := strconv.Atoi(issueNbStr)
 	if err != nil {
-		log.Fatal(err.Error())
+		log.Panic(err.Error())
 	}
 	return nb
 }
@@ -166,12 +166,12 @@ func CheckReleaseBlockerIssues(repo, majorRelease string) map[string]any {
 
 	byteRes, _, err := gh.Exec("issue", "list", "--json", "title,url,labels", "--repo", repo)
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Panicf(err.Error())
 	}
 	var issues []Issue
 	err = json.Unmarshal(byteRes.Bytes(), &issues)
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Panicf(err.Error())
 	}
 
 	var mustClose []Issue
@@ -204,13 +204,13 @@ func LoadKnownIssues(repo, majorRelease string) []Issue {
 		"--json", "title,number",
 	)
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 
 	var knownIssues []Issue
 	err = json.Unmarshal(byteRes.Bytes(), &knownIssues)
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 	return knownIssues
 }

--- a/go/releaser/github/milestone.go
+++ b/go/releaser/github/milestone.go
@@ -40,14 +40,14 @@ func GetMilestonesByName(repo, name string) []Milestone {
 		"--state", "all",
 	)
 	if err != nil {
-		log.Fatal(err.Error())
+		log.Panic(err.Error())
 	}
 	str := stdOut.String()
 	str = str[strings.Index(str, "]")+1:]
 	var ms []Milestone
 	err = json.Unmarshal([]byte(str), &ms)
 	if err != nil {
-		log.Fatal(err.Error())
+		log.Panic(err.Error())
 	}
 	return ms
 }
@@ -59,7 +59,7 @@ func CreateNewMilestone(repo, name string) string {
 		"--title", name,
 	)
 	if err != nil {
-		log.Fatal(err.Error())
+		log.Panic(err.Error())
 	}
 	out := strings.ReplaceAll(stdOut.String(), "\n", "")
 	idx := strings.LastIndex(out, fmt.Sprintf("https://github.com/%s/milestone/", repo))
@@ -69,7 +69,7 @@ func CreateNewMilestone(repo, name string) string {
 func CloseMilestone(repo, name string) string {
 	ms := GetMilestonesByName(repo, name)
 	if len(ms) != 1 {
-		log.Fatalf("expected to find one milestone found %d", len(ms))
+		log.Panicf("expected to find one milestone found %d", len(ms))
 	}
 
 	stdOut, _, err := gh.Exec(
@@ -79,7 +79,7 @@ func CloseMilestone(repo, name string) string {
 		"--state", "closed",
 	)
 	if err != nil {
-		log.Fatal(err.Error())
+		log.Panic(err.Error())
 	}
 	out := strings.ReplaceAll(stdOut.String(), "\n", "")
 	idx := strings.LastIndex(out, fmt.Sprintf("https://github.com/%s/milestone/", repo))

--- a/go/releaser/github/pr.go
+++ b/go/releaser/github/pr.go
@@ -62,7 +62,7 @@ func (p *PR) Create(repo string) (nb int, url string) {
 		"--base", p.Base,
 	)
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 	url = strings.ReplaceAll(stdOut.String(), "\n", "")
 	nb = URLToNb(url)
@@ -76,7 +76,7 @@ func IsPRMerged(repo string, nb int) bool {
 		"--json", "mergedAt",
 	)
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 
 	// If the PR is not merged, the output of the gh command will be:
@@ -93,12 +93,12 @@ func CheckBackportToPRs(repo, majorRelease string) map[string]any {
 
 	byteRes, _, err := gh.Exec("pr", "list", "--json", "title,baseRefName,url,labels", "--repo", repo)
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Panicf(err.Error())
 	}
 	var prs []PR
 	err = json.Unmarshal(byteRes.Bytes(), &prs)
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Panicf(err.Error())
 	}
 
 	var mustClose []PR
@@ -133,12 +133,12 @@ func FindPR(repo, prTitle string) (nb int, url string) {
 		"--state", "open",
 	)
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Panicf(err.Error())
 	}
 	var prs []PR
 	err = json.Unmarshal(byteRes.Bytes(), &prs)
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Panicf(err.Error())
 	}
 	if len(prs) != 1 {
 		return 0, ""
@@ -157,12 +157,12 @@ func GetMergedPRsAndAuthorsByMilestone(repo, milestone string) (prs []PR, author
 		"--repo", repo,
 	)
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 
 	err = json.Unmarshal(byteRes.Bytes(), &prs)
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 
 	// Get the full list of distinct PRs authors and sort them
@@ -190,13 +190,13 @@ func GetOpenedPRsByMilestone(repo, milestone string) []PR {
 		"--repo", repo,
 	)
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 
 	var prs []PR
 	err = json.Unmarshal(byteRes.Bytes(), &prs)
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 	return prs
 }
@@ -210,7 +210,7 @@ func AssignMilestoneToPRs(repo, milestone string, prs []PR) {
 			"--repo", repo,
 		)
 		if err != nil {
-			log.Fatal(err)
+			log.Panic(err)
 		}
 	}
 }

--- a/go/releaser/github/release.go
+++ b/go/releaser/github/release.go
@@ -56,7 +56,7 @@ func CreateRelease(repo, tag, notesFilePath string, latest, prerelease bool) (ur
 		if strings.Contains(err.Error(), "already exists") {
 			return fmt.Sprintf("https://github.com/%s/releases/tag/%s", repo, tag)
 		}
-		log.Fatal(err)
+		log.Panic(err)
 	}
 	return strings.ReplaceAll(stdOut.String(), "\n", "")
 }

--- a/go/releaser/github/user.go
+++ b/go/releaser/github/user.go
@@ -26,13 +26,13 @@ import (
 func CurrentUser() string {
 	exec, _, err := gh.Exec("api", "user")
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Panicf(err.Error())
 	}
 	x := map[string]any{}
 
 	err = json.Unmarshal(exec.Bytes(), &x)
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Panicf(err.Error())
 	}
 
 	return x["login"].(string)

--- a/go/releaser/issue.go
+++ b/go/releaser/issue.go
@@ -290,7 +290,7 @@ func (s *State) LoadIssue() {
 	if idx := strings.Index(title, "-RC"); idx != -1 {
 		rc, err := strconv.Atoi(title[idx+len("-RC"):])
 		if err != nil {
-			log.Fatal(err)
+			log.Panic(err)
 		}
 		newIssue.RC = rc
 	}
@@ -307,7 +307,7 @@ func (s *State) LoadIssue() {
 				nline := strings.TrimSpace(line[len(dateItem):])
 				parsedDate, err := time.Parse("Mon _2 Jan 2006", nline)
 				if err != nil {
-					log.Fatal(err)
+					log.Panic(err)
 				}
 				newIssue.Date = parsedDate
 			}
@@ -523,12 +523,12 @@ func (i *Issue) toString() string {
 
 	parsed, err := tmpl.Parse(releaseIssueTemplate)
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 	b := bytes.NewBufferString("")
 	err = parsed.Execute(b, i)
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 	return b.String()
 }

--- a/go/releaser/milestone.go
+++ b/go/releaser/milestone.go
@@ -33,7 +33,7 @@ func FindVersionAfterNextRelease(state *State) string {
 	for _, segment := range segments {
 		v, err := strconv.Atoi(segment)
 		if err != nil {
-			log.Fatal(err.Error())
+			log.Panic(err.Error())
 		}
 		segmentInts = append(segmentInts, v)
 	}

--- a/go/releaser/pre_release/code_freeze.go
+++ b/go/releaser/pre_release/code_freeze.go
@@ -149,7 +149,7 @@ func CodeFreeze(state *releaser.State) (*logging.ProgressLogging, func() string)
 func isCurrentBranchFrozen() bool {
 	b, err := os.ReadFile(codeFreezeWorkflowFile)
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 	str := string(b)
 	return strings.Contains(str, "exit 1")
@@ -167,12 +167,12 @@ func changeCodeFreezeWorkflow(s codeFreezeStatus) {
 	// sed -i.bak -E "s/exit (.*)/exit 0/g" $code_freeze_workflow
 	out, err := exec.Command("sed", "-i.bak", "-E", fmt.Sprintf("s/exit (.*)/exit %d/g", s), codeFreezeWorkflowFile).CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 
 	// remove backup file left by the sed command
 	out, err = exec.Command("rm", "-f", fmt.Sprintf("%s.bak", codeFreezeWorkflowFile)).CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 }

--- a/go/releaser/pre_release/create_release_pr.go
+++ b/go/releaser/pre_release/create_release_pr.go
@@ -180,7 +180,7 @@ func findFilesRecursive() []string {
 			return nil
 		})
 		if err != nil {
-			log.Fatal(err.Error())
+			log.Panic(err.Error())
 		}
 	}
 	return files
@@ -196,14 +196,14 @@ func updateExamples(newVersion, vtopNewVersion string) {
 	args := append([]string{"-i.bak", "-E", fmt.Sprintf("s/vitess\\/lite:(.*)/vitess\\/lite:v%s/g", newVersion)}, files...)
 	out, err := exec.Command("sed", args...).CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 
 	// sed -i.bak -E "s/vitess\/vtadmin:(.*)/vitess\/vtadmin:v$1/g" $compose_example_files $compose_example_sub_files $vtop_example_files
 	args = append([]string{"-i.bak", "-E", fmt.Sprintf("s/vitess\\/vtadmin:(.*)/vitess\\/vtadmin:v%s/g", newVersion)}, files...)
 	out, err = exec.Command("sed", args...).CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 
 	// modify the docker image tag used for planetscale/vitess-operator
@@ -213,7 +213,7 @@ func updateExamples(newVersion, vtopNewVersion string) {
 		args = append([]string{"-i.bak", "-E", fmt.Sprintf("s/planetscale\\/vitess-operator:(.*)/planetscale\\/vitess-operator:v%s/g", vtopNewVersion)}, files...)
 		out, err = exec.Command("sed", args...).CombinedOutput()
 		if err != nil {
-			log.Fatalf("%s: %s", err, out)
+			log.Panicf("%s: %s", err, out)
 		}
 	}
 
@@ -225,14 +225,14 @@ func updateExamples(newVersion, vtopNewVersion string) {
 	args = append([]string{"-f"}, filesBackups...)
 	out, err = exec.Command("rm", args...).CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 }
 
 func UpdateVersionGoFile(newVersion string) {
 	err := os.WriteFile(versionGoFile, []byte(fmt.Sprintf(versionGo, time.Now().Year(), newVersion)), os.ModePerm)
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 }
 
@@ -242,11 +242,11 @@ func UpdateJavaDir(newVersion string) {
 	cmd := exec.Command("mvn", "versions:set", fmt.Sprintf("-DnewVersion=%s", newVersion))
 	pwd, err := os.Getwd()
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 	cmd.Dir = path.Join(pwd, "/java")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 }

--- a/go/releaser/pre_release/release_notes.go
+++ b/go/releaser/pre_release/release_notes.go
@@ -131,7 +131,7 @@ func getSegmentOfReleaseNotesDir(version string) (prefix string, major string, p
 	rx := regexp.MustCompile(`([0-9]+)\.([0-9]+)\.([0-9]+)`)
 	versionMatch := rx.FindStringSubmatch(version)
 	if len(versionMatch) != 4 {
-		log.Fatal("could not parse the release version when generating the release notes")
+		log.Panic("could not parse the release version when generating the release notes")
 	}
 
 	majorVersion := versionMatch[1] + "." + versionMatch[2]
@@ -147,7 +147,7 @@ func generateReleaseNotes(state *releaser.State, version string) {
 
 	err := os.MkdirAll(releaseNotesPath, os.ModePerm)
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 
 	releaseNotes := releaseNote{
@@ -159,7 +159,7 @@ func generateReleaseNotes(state *releaser.State, version string) {
 	// summary of the release
 	_, err = os.Stat(summaryFile)
 	if err != nil && !os.IsNotExist(err) {
-		log.Fatal(err)
+		log.Panic(err)
 	} else if err == nil {
 		releaseNotes.Announcement = releaseSummary(summaryFile)
 	}
@@ -188,7 +188,7 @@ Thanks to all our contributors: @%s
 	// go run ./go/tools/releases/releases.go
 	out, err := exec.Command("go", "run", "./go/tools/releases/releases.go").CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 }
 
@@ -197,24 +197,24 @@ func (rn *releaseNote) generate() {
 	rn.PathToChangeLogFileOnGH = fmt.Sprintf(releaseNotesPathGitHub, rn.ctx.VitessRelease.Repo) + path.Join(rn.SubDirPath, "changelog.md")
 	rnFile, err := os.OpenFile(path.Join(rn.SubDirPath, "release_notes.md"), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 
 	t := template.Must(template.New("release_notes").Parse(markdownTemplate))
 	err = t.ExecuteTemplate(rnFile, "release_notes", rn)
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 
 	// Generate the changelog
 	changelogFile, err := os.OpenFile(path.Join(rn.SubDirPath, "changelog.md"), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 	t = template.Must(template.New("release_notes_changelog").Parse(markdownTemplateChangelog))
 	err = t.ExecuteTemplate(changelogFile, "release_notes_changelog", rn)
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 }
 
@@ -283,7 +283,7 @@ func createSortedPrTypeSlice(prPerType prsByType) []sortedPRType {
 func releaseSummary(summaryFile string) string {
 	contentSummary, err := os.ReadFile(summaryFile)
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 	return string(contentSummary)
 }
@@ -294,7 +294,7 @@ func getStringForPullRequestInfos(repo string, prPerType prsByType) string {
 	t := template.Must(template.New("markdownTemplatePR").Parse(fmt.Sprintf(markdownTemplatePR, repo)))
 	buff := bytes.Buffer{}
 	if err := t.ExecuteTemplate(&buff, "markdownTemplatePR", data); err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 	return buff.String()
 }
@@ -306,7 +306,7 @@ func getStringForKnownIssues(issues []github.Issue) string {
 	t := template.Must(template.New("markdownTemplateKnownIssues").Parse(markdownTemplateKnownIssues))
 	buff := bytes.Buffer{}
 	if err := t.ExecuteTemplate(&buff, "markdownTemplateKnownIssues", issues); err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 	return buff.String()
 }

--- a/go/releaser/pre_release/vtop_update_golang.go
+++ b/go/releaser/pre_release/vtop_update_golang.go
@@ -131,32 +131,32 @@ func VtopUpdateGolang(state *releaser.State) (*logging.ProgressLogging, func() s
 func updateGolangVersionForVtop(targetGoVersion *version.Version) {
 	out, err := exec.Command("sed", "-i.bak", "-E", fmt.Sprintf("s/^go (.*)/go %s/g", targetGoVersion.String()), "go.mod").CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 	out, err = exec.Command("rm", "-f", "go.mod.bak").CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 
 	out, err = exec.Command("sed", "-i.bak", "-E", fmt.Sprintf("s/^FROM golang:(.*) AS build/FROM golang:%s AS build/g", targetGoVersion.String()), "build/Dockerfile.release").CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 	out, err = exec.Command("rm", "-f", "build/Dockerfile.release.bak").CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 
 	workflowFiles := findVtopWorkflowFiles()
 	args := append([]string{"-i.bak", "-E", fmt.Sprintf("s/go-version: (.*)/go-version: %s/g", targetGoVersion.String())}, workflowFiles...)
 	out, err = exec.Command("sed", args...).CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 	for _, file := range workflowFiles {
 		out, err = exec.Command("rm", "-f", fmt.Sprintf("%s.bak", file)).CombinedOutput()
 		if err != nil {
-			log.Fatalf("%s: %s", err, out)
+			log.Panicf("%s: %s", err, out)
 		}
 	}
 }
@@ -173,7 +173,7 @@ func findVtopWorkflowFiles() []string {
 		return nil
 	})
 	if err != nil {
-		log.Fatal(err.Error())
+		log.Panic(err.Error())
 	}
 	return files
 }
@@ -181,18 +181,18 @@ func findVtopWorkflowFiles() []string {
 func currentGolangVersionInVitess() *version.Version {
 	contentRaw, err := os.ReadFile("build.env")
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 	content := string(contentRaw)
 
 	versre := regexp.MustCompile(regexpFindGolangVersionInVitess)
 	versionStr := versre.FindStringSubmatch(content)
 	if len(versionStr) != 2 {
-		log.Fatalf("malformatted error, got: %v", versionStr)
+		log.Panicf("malformatted error, got: %v", versionStr)
 	}
 	v, err := version.NewVersion(versionStr[1])
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 	return v
 }
@@ -200,7 +200,7 @@ func currentGolangVersionInVitess() *version.Version {
 func currentGolangVersionInVtop() *version.Version {
 	contentRaw, err := os.ReadFile("go.mod")
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 	content := string(contentRaw)
 
@@ -213,10 +213,10 @@ func currentGolangVersionInVtop() *version.Version {
 		}
 		v, err := version.NewVersion(versionStr[1])
 		if err != nil {
-			log.Fatal(err)
+			log.Panic(err)
 		}
 		return v
 	}
-	log.Fatal("could not parse the go.mod")
+	log.Panic("could not parse the go.mod")
 	return nil
 }

--- a/go/releaser/release/merge_pr.go
+++ b/go/releaser/release/merge_pr.go
@@ -37,7 +37,7 @@ func MergeReleasePR(state *releaser.State) (*logging.ProgressLogging, func() str
 		url := state.Issue.CreateReleasePR.URL
 		nb, err := strconv.Atoi(url[strings.LastIndex(url, "/")+1:])
 		if err != nil {
-			log.Fatal(err)
+			log.Panic(err)
 		}
 
 		pl.NewStepf("Waiting for %s to be merged", url)

--- a/go/releaser/release/tag_release.go
+++ b/go/releaser/release/tag_release.go
@@ -51,7 +51,7 @@ func TagRelease(state *releaser.State) (*logging.ProgressLogging, func() string)
 		// i.e. if we release v17.0.1, we also want to tag: v0.17.1
 		nextReleaseSplit := strings.Split(lowerCaseRelease, ".")
 		if len(nextReleaseSplit) != 3 {
-			log.Fatalf("%s was not formated x.x.x", state.VitessRelease.Release)
+			log.Panicf("%s was not formated x.x.x", state.VitessRelease.Release)
 		}
 		gdocGitTag := fmt.Sprintf("v0.%s.%s", nextReleaseSplit[0], nextReleaseSplit[2])
 		git.TagAndPush(state.VitessRelease.Remote, gdocGitTag)

--- a/go/releaser/release/vtop_create_release_pr.go
+++ b/go/releaser/release/vtop_create_release_pr.go
@@ -229,19 +229,19 @@ func updateVitessDeps(state *releaser.State) {
 
 	out, err := exec.Command("go", "get", "-u", fmt.Sprintf("vitess.io/vitess@%s", strings.ToLower(state.VitessRelease.Release))).CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 
 	out, err = exec.Command("go", "mod", "tidy").CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 }
 
 func updateVtOpVersionGoFile(newVersion string) {
 	err := os.WriteFile(vtopVersionGoFile, []byte(fmt.Sprintf(vtopVersionGo, time.Now().Year(), newVersion)), os.ModePerm)
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 }
 
@@ -266,28 +266,28 @@ func updateVtopTests(vitessPreviousVersion, vitessNewVersion string) {
 	args := append([]string{"-i.bak", "-E", fmt.Sprintf("s/vitess\\/lite:([^-]*)(-rc[0-9]*)?(-mysql.*)?/vitess\\/lite:v%s\\3/g", vitessNewVersion)}, testFiles...)
 	out, err := exec.Command("sed", args...).CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 
 	// sed -i.bak -E "s/vitess\/vtadmin:([^-]*)(-rc[0-9]*)?(-mysql.*)?/vitess\/vtadmin:v$new_vitess_version\3/g" $operator_files
 	args = append([]string{"-i.bak", "-E", fmt.Sprintf("s/vitess\\/vtadmin:([^-]*)(-rc[0-9]*)?(-mysql.*)?/vitess\\/vtadmin:v%s\\3/g", vitessNewVersion)}, testFiles...)
 	out, err = exec.Command("sed", args...).CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 
 	// sed -i.bak -E "s/vitess\/lite:([^-]*)(-rc[0-9]*)?(-mysql.*)?/vitess\/lite:v$new_vitess_version\3\"/g" $ROOT/pkg/apis/planetscale/v2/defaults.go
 	args = append([]string{"-i.bak", "-E", fmt.Sprintf("s/vitess\\/lite:([^-]*)(-rc[0-9]*)?(-mysql.*)?/vitess\\/lite:v%s\\3\"/g", vitessNewVersion)}, vtopDefaultsFile)
 	out, err = exec.Command("sed", args...).CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 
 	// sed -i.bak -E "s/vitess\/lite:([^-]*)(-rc[0-9]*)?(-mysql.*)?/vitess\/lite:v$old_vitess_version\3/g" $ROOT/test/endtoend/operator/101_initial_cluster.yaml
 	args = append([]string{"-i.bak", "-E", fmt.Sprintf("s/vitess\\/lite:([^-]*)(-rc[0-9]*)?(-mysql.*)?/vitess\\/lite:v%s\\3/g", vitessPreviousVersion)}, vtopInitialClusterFile)
 	out, err = exec.Command("sed", args...).CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 
 	filesBackups := make([]string, 0, len(testFiles)+1)
@@ -299,7 +299,7 @@ func updateVtopTests(vitessPreviousVersion, vitessNewVersion string) {
 	args = append([]string{"-f"}, filesBackups...)
 	out, err = exec.Command("rm", args...).CombinedOutput()
 	if err != nil {
-		log.Fatalf("%s: %s", err, out)
+		log.Panicf("%s: %s", err, out)
 	}
 }
 
@@ -315,7 +315,7 @@ func vtopTestFiles() []string {
 		return nil
 	})
 	if err != nil {
-		log.Fatal(err.Error())
+		log.Panic(err.Error())
 	}
 	return files
 }
@@ -326,14 +326,14 @@ func findNextVtOpVersion(version string, rc int) string {
 	}
 	segments := strings.Split(version, ".")
 	if len(segments) != 3 {
-		log.Fatal("expected three segments")
+		log.Panic("expected three segments")
 	}
 
 	segmentInts := make([]int, 0, len(segments))
 	for _, segment := range segments {
 		v, err := strconv.Atoi(segment)
 		if err != nil {
-			log.Fatal(err.Error())
+			log.Panic(err.Error())
 		}
 		segmentInts = append(segmentInts, v)
 	}

--- a/go/releaser/state.go
+++ b/go/releaser/state.go
@@ -82,11 +82,11 @@ func (s *State) GoToVtOp() {
 func changeDir(p string) {
 	cwd, err := syscall.Getwd()
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 	p = path.Join(cwd, p)
 	err = syscall.Chdir(p)
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 }

--- a/go/releaser/vitess.go
+++ b/go/releaser/vitess.go
@@ -63,11 +63,11 @@ func FindNextRelease(remote, majorRelease string, isVtOp bool) (
 		if len(mainMajorParts) == 2 && len(majorParts) == 2 {
 			mainMajorNb, err := strconv.Atoi(mainMajorParts[1])
 			if err != nil {
-				log.Fatal(err)
+				log.Panic(err)
 			}
 			majorNb, err := strconv.Atoi(majorParts[1])
 			if err != nil {
-				log.Fatal(err)
+				log.Panic(err)
 			}
 			if mainMajorNb+1 == majorNb {
 				return fmt.Sprintf("%s.%d.0", mainMajorParts[0], mainMajorNb+1), releaseBranchName, true, true
@@ -87,16 +87,16 @@ func FindNextRelease(remote, majorRelease string, isVtOp bool) (
 	// if the current release and the wanted release are different, it means there is an
 	// error, we were not able to find the proper branch / corresponding release
 	if major != majorRelease {
-		log.Fatalf("on branch '%s', could not find the corresponding major release '%s'", releaseBranchName, majorRelease)
+		log.Panicf("on branch '%s', could not find the corresponding major release '%s'", releaseBranchName, majorRelease)
 	}
 
 	mainMajorNb, err := strconv.ParseFloat(mainMajor, 64)
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 	majorNb, err := strconv.ParseFloat(major, 64)
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 	return currentRelease, releaseBranchName, mainMajorNb-1 == majorNb, false
 }
@@ -104,7 +104,7 @@ func FindNextRelease(remote, majorRelease string, isVtOp bool) (
 func FindPreviousRelease(remote, currentMajor string) string {
 	majorNb, err := strconv.Atoi(currentMajor)
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 
 	previousMajor := majorNb - 1
@@ -120,7 +120,7 @@ func getCurrentReleaseVitess() string {
 	// sed -n 's/.*versionName.*\"\([[:digit:]\.]*\).*\"/\1/p' ./go/vt/servenv/version.go
 	out, err := exec.Command("sed", "-n", "s/.*versionName.*\"\\([[:digit:]\\.]*\\).*\"/\\1/p", "./go/vt/servenv/version.go").CombinedOutput()
 	if err != nil {
-		log.Fatalf("%v: %s", err, out)
+		log.Panicf("%v: %s", err, out)
 	}
 
 	outStr := string(out)
@@ -132,7 +132,7 @@ func getCurrentReleaseVtOp() string {
 	// sed -n 's/.*Version.*\"\([[:digit:]\.]*\).*\"/\1/p' ./version/version.go
 	out, err := exec.Command("sed", "-n", "s/.*Version =.*\"\\([[:digit:]\\.]*\\).*\"/\\1/p", "./version/version.go").CombinedOutput()
 	if err != nil {
-		log.Fatalf("%v: %s", err, out)
+		log.Panicf("%v: %s", err, out)
 	}
 
 	outStr := string(out)
@@ -146,7 +146,7 @@ func releaseToMajorVitess(release string) string {
 func releaseToMajorVtOp(release string) string {
 	parts := strings.Split(release, ".")
 	if len(parts) != 3 {
-		log.Fatalf("expected the vtop version to have format x.x.x but was %s", release)
+		log.Panicf("expected the vtop version to have format x.x.x but was %s", release)
 	}
 	return fmt.Sprintf("%s.%s", parts[0], parts[1])
 }


### PR DESCRIPTION
Moving all the `logs.Fatal` to `logs.Panic` in order to ease debugging if something goes wrong during a release