### PR TITLE
Fix branch protection rules copy

### DIFF
--- a/go/releaser/github/branch.go
+++ b/go/releaser/github/branch.go
@@ -120,8 +120,8 @@ type updateRequiredStatusChecks struct {
 }
 
 type updateUsersTeamsApps struct {
-	Users []string `json:"users,omitempty"`
-	Teams []string `json:"teams,omitempty"`
+	Users []string `json:"users"`
+	Teams []string `json:"teams"`
 	Apps  []string `json:"apps"`
 }
 


### PR DESCRIPTION
Fix an issue seen during RC-1, the fields were not sent to the API although they are mandatory, leading to a panic