### PR TITLE
Fix how the status of the general prerequisite is handled

### DIFF
--- a/go/interactive/general_prereq.go
+++ b/go/interactive/general_prereq.go
@@ -60,7 +60,11 @@ func generalPrerequisiteUpdate(mi *ui.MenuItem, msg tea.Msg) (*ui.MenuItem, tea.
 		if string(msg) != mi.Name {
 			return mi, nil
 		}
-		mi.State.Issue.General.InverseItemStatus()
+		if mi.IsDone {
+			mi.State.Issue.General.MarkAllAsNotDone()
+		} else {
+			mi.State.Issue.General.MarkAllAsDone()
+		}
 		mi.IsDone = !mi.IsDone
 		pl, fn := mi.State.UploadIssue()
 		return mi, tea.Batch(func() tea.Msg {

--- a/go/releaser/issue.go
+++ b/go/releaser/issue.go
@@ -329,9 +329,15 @@ func (pi *ParentOfItems) ItemsLeft() int {
 	return nb
 }
 
-func (pi *ParentOfItems) InverseItemStatus() {
+func (pi *ParentOfItems) MarkAllAsDone() {
 	for i, _ := range pi.Items {
-		pi.Items[i].Done = !pi.Items[i].Done
+		pi.Items[i].Done = true
+	}
+}
+
+func (pi *ParentOfItems) MarkAllAsNotDone() {
+	for i, _ := range pi.Items {
+		pi.Items[i].Done = false
 	}
 }
 


### PR DESCRIPTION
There was an issue where the status (done/not done) of the general prerequisite step was not saved properly on the issue. Now, in the UI when marking the item as done/not done, all the items of the list are checked or unchecked.