### PR TITLE
Fix how we list backports

### DIFF
--- a/go/releaser/github/pr.go
+++ b/go/releaser/github/pr.go
@@ -81,7 +81,7 @@ func IsPRMerged(repo string, nb int) bool {
 	return !strings.Contains(stdOut, "null")
 }
 
-func CheckBackportToPRs(repo, majorRelease string) map[string]any {
+func CheckBackportToPRs(repo, branch string) map[string]any {
 	git.CorrectCleanRepo(repo)
 
 	stdOut := execGh("pr", "list", "--json", "title,baseRefName,url,labels", "--repo", repo)
@@ -93,13 +93,12 @@ func CheckBackportToPRs(repo, majorRelease string) map[string]any {
 
 	var mustClose []PR
 
-	branchName := fmt.Sprintf("release-%s.0", majorRelease)
 	for _, pr := range prs {
-		if pr.Base == branchName {
+		if pr.Base == branch {
 			mustClose = append(mustClose, pr)
 		}
 		for _, l := range pr.Labels {
-			if strings.HasPrefix(l.Name, "Backport to: ") && strings.Contains(l.Name, branchName) {
+			if strings.HasPrefix(l.Name, "Backport to: ") && strings.Contains(l.Name, branch) {
 				mustClose = append(mustClose, pr)
 			}
 		}

--- a/go/releaser/issue.go
+++ b/go/releaser/issue.go
@@ -62,7 +62,7 @@ const (
 	generalPrerequisitesItem = "General prerequisites."
 	preSlackAnnouncementItem = "Notify the community on Slack."
 	checkSummaryItem         = "Make sure the release notes summary is prepared and clean."
-	backportItem             = "Make sure backport Pull Requests are merged, list below."
+	backportItem             = "Make sure important Pull Requests are merged, list below."
 	releaseBlockerItem       = "Make sure release blocker Issues are closed, list below."
 	draftBlogPostItem        = "Draft the release blog post."
 	crossBlogPostItem        = "Send requests to cross-post the blog post (CNCF, PlanetScale)."
@@ -193,11 +193,7 @@ const (
 {{- end }}
 - [{{fmtStatus .SlackPreRequisite}}] Notify the community on Slack.
 - [{{fmtStatus .CheckSummary}}] Make sure the release notes summary is prepared and clean.
-{{- if eq .RC 0 }}
-- Make sure backport Pull Requests are merged, list below.
-{{- else }}
 - Make sure important Pull Requests are merged, list below.
-{{- end }}
 {{- range $item := .CheckBackport.Items }}
   - [{{fmtStatus $item.Done}}] {{$item.URL}}
 {{- end }}
@@ -378,7 +374,7 @@ func (s *State) LoadIssue() {
 		case stateReadingItem:
 			// divers
 			if strings.HasPrefix(line, dateItem) {
-				nline := strings.TrimSpace(line[len(dateItem) : len(line)-1])
+				nline := strings.TrimSpace(line[len(dateItem) : len(line)-2])
 				parsedDate, err := time.Parse("Mon _2 Jan 2006", nline)
 				if err != nil {
 					utils.LogPanic(err, "failed to parse the date from the release issue body (%s)", nline)

--- a/go/releaser/prerequisite/check_and_add.go
+++ b/go/releaser/prerequisite/check_and_add.go
@@ -34,7 +34,7 @@ func CheckAndAddPRsIssues(state *releaser.State) (*logging.ProgressLogging, func
 		state.LoadIssue()
 
 		pl.NewStepf("Check and add Pull Requests")
-		prsOnGH := github.CheckBackportToPRs(state.VitessRelease.Repo, state.VitessRelease.MajorRelease)
+		prsOnGH := github.CheckBackportToPRs(state.VitessRelease.Repo, state.VitessRelease.ReleaseBranch)
 		state.Issue.CheckBackport = addLinksToParentOfItems(state.Issue.CheckBackport, prsOnGH)
 
 		pl.NewStepf("Check and add Release Blocker Issues")


### PR DESCRIPTION
There was an issue when doing RC-1 we were overriding all previous listed backports/prs in the issue. Also the branch we used to list important PRs was wrong. Also a minor issue with how we parsed the date in the issue.