### PR TITLE
Fix the links in the check docker step

### DIFF
--- a/go/cmd/cmd.go
+++ b/go/cmd/cmd.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -138,12 +139,18 @@ func setUpVitessReleaseInformation(s *releaser.State, repo string, rc int) (rele
 		utils.LogPanic(nil, "wanted: RC %d but release branch was %s, latest release was %v and is from main is %v", rcIncrement, releaseBranch, isLatestRelease, isFromMain)
 	}
 
+	majorReleaseNb, err := strconv.Atoi(releaseVersion)
+	if err != nil {
+		utils.LogPanic(err, "could not parse the release version")
+	}
+
 	vitessRelease := releaser.ReleaseInformation{
 		Repo:              repo,
 		Remote:            remote,
 		ReleaseBranch:     releaseBranch,
 		BaseReleaseBranch: baseReleaseBranch,
 		MajorRelease:      releaseVersion,
+		MajorReleaseNb:    majorReleaseNb,
 		IsLatestRelease:   isLatestRelease,
 		Release:           releaseFromIssue,
 		GA:                ga,

--- a/go/interactive/menu_item_constructors.go
+++ b/go/interactive/menu_item_constructors.go
@@ -98,7 +98,7 @@ func dockerImagesItem(ctx context.Context) *ui.MenuItem {
 	state := releaser.UnwrapState(ctx)
 	return newBooleanMenu(
 		ctx,
-		release.CheckDockerMessage(state.VitessRelease.Repo),
+		release.CheckDockerMessage(state.VitessRelease.MajorReleaseNb, state.VitessRelease.Repo),
 		steps.DockerImages,
 		func() { state.Issue.DockerImages = !state.Issue.DockerImages },
 		state.Issue.DockerImages,

--- a/go/releaser/release/docker.go
+++ b/go/releaser/release/docker.go
@@ -18,13 +18,23 @@ package release
 
 import "fmt"
 
-func CheckDockerMessage(repo string) []string {
-	return []string{
+func CheckDockerMessage(majorRelease int, repo string) []string {
+	msg := []string{
 		"Make sure the Docker Images are being built by GitHub Actions.",
 		"This can be done by visiting the following links, our new release should appear in either green (done) or yellow (building / pending build):",
 		"",
-		fmt.Sprintf("\t- https://github.com/%s/actions/workflows/docker_build_base.yml", repo),
-		fmt.Sprintf("\t- https://github.com/%s/actions/workflows/docker_build_lite.yml", repo),
 		fmt.Sprintf("\t- https://github.com/%s/actions/workflows/docker_build_vttestserver.yml", repo),
 	}
+
+	// Hack: versions < v20 and versions >= v20 use different GitHub Actions workflows to build the Docker images.
+	if majorRelease < 20 {
+		msg = append(msg,
+			fmt.Sprintf("\t- https://github.com/%s/actions/workflows/docker_build_base.yml", repo),
+			fmt.Sprintf("\t- https://github.com/%s/actions/workflows/docker_build_lite.yml", repo),
+		)
+	} else {
+		msg = append(msg, fmt.Sprintf("\t- https://github.com/%s/actions/workflows/docker_build_images.yml", repo))
+	}
+
+	return msg
 }

--- a/go/releaser/state.go
+++ b/go/releaser/state.go
@@ -52,6 +52,7 @@ type ReleaseInformation struct {
 	BaseReleaseBranch string
 
 	MajorRelease    string
+	MajorReleaseNb  int
 	Release         string
 	IsLatestRelease bool
 	GA              bool


### PR DESCRIPTION
The links for `>= v20` releases in the Docker step were outdated as we recently changed the workflow used to build docker images.