### PR TITLE
Automate the creation of the release-blocker label

### DIFF
--- a/go/interactive/code_freeze/create_new_labels.go
+++ b/go/interactive/code_freeze/create_new_labels.go
@@ -26,41 +26,41 @@ import (
 	"vitess.io/vitess-releaser/go/releaser/steps"
 )
 
-func CreateBackportToLabelMenuItem(ctx context.Context) *ui.MenuItem {
+func CreateNewLabelsMenuItem(ctx context.Context) *ui.MenuItem {
 	state := releaser.UnwrapState(ctx)
-	act := createBackportToLabelAct
-	if state.Issue.CreateBackportToLabel.Done {
+	act := createNewLabelsAct
+	if state.Issue.CreateNewLabels.Done {
 		act = nil
 	}
 	return &ui.MenuItem{
 		State:  state,
-		Name:   steps.CreateBackportToLabel,
+		Name:   steps.CreateNewLabels,
 		Act:    act,
-		Update: createBackportToLabelUpdate,
-		IsDone: state.Issue.CreateBackportToLabel.Done,
-		Info:   state.Issue.CreateBackportToLabel.URL,
+		Update: createNewLabelsUpdate,
+		IsDone: state.Issue.CreateNewLabels.Done,
+		Info:   state.Issue.CreateNewLabels.URL,
 
 		// We only need to run this step when we are creating a new branch, aka doing RC-1
 		Ignore: state.Issue.RC != 1,
 	}
 }
 
-type createBackportToLabelUrl string
+type createNewLabelsUrl string
 
-func createBackportToLabelUpdate(mi *ui.MenuItem, msg tea.Msg) (*ui.MenuItem, tea.Cmd) {
-	_, ok := msg.(createBackportToLabelUrl)
+func createNewLabelsUpdate(mi *ui.MenuItem, msg tea.Msg) (*ui.MenuItem, tea.Cmd) {
+	_, ok := msg.(createNewLabelsUrl)
 	if !ok {
 		return mi, nil
 	}
 
-	mi.IsDone = mi.State.Issue.CreateBackportToLabel.Done
-	mi.Info = mi.State.Issue.CreateBackportToLabel.URL
+	mi.IsDone = mi.State.Issue.CreateNewLabels.Done
+	mi.Info = mi.State.Issue.CreateNewLabels.URL
 	return mi, nil
 }
 
-func createBackportToLabelAct(mi *ui.MenuItem) (*ui.MenuItem, tea.Cmd) {
-	pl, create := code_freeze.CreateBackportToLabel(mi.State)
+func createNewLabelsAct(mi *ui.MenuItem) (*ui.MenuItem, tea.Cmd) {
+	pl, create := code_freeze.CreateNewLabels(mi.State)
 	return mi, tea.Batch(func() tea.Msg {
-		return createBackportToLabelUrl(create())
-	}, ui.PushDialog(ui.NewProgressDialog("Create Backport To label", pl)))
+		return createNewLabelsUrl(create())
+	}, ui.PushDialog(ui.NewProgressDialog("Create New Labels", pl)))
 }

--- a/go/interactive/main_menu.go
+++ b/go/interactive/main_menu.go
@@ -50,7 +50,7 @@ func MainScreen(ctx context.Context, state *releaser.State) {
 		"Code Freeze",
 		code_freeze.CodeFreezeMenuItem(ctx),
 		code_freeze.CopyBranchProtectionMenuItem(ctx),
-		code_freeze.CreateBackportToLabelMenuItem(ctx),
+		code_freeze.CreateNewLabelsMenuItem(ctx),
 		code_freeze.UpdateSnapshotOnMainMenuItem(ctx),
 		code_freeze.CreateMilestoneMenuItem(ctx),
 	)

--- a/go/releaser/code_freeze/create_new_labels.go
+++ b/go/releaser/code_freeze/create_new_labels.go
@@ -30,7 +30,7 @@ const (
 	backportToLabelDesc  = "Needs to be backport to "
 )
 
-func CreateBackportToLabel(state *releaser.State) (*logging.ProgressLogging, func() string) {
+func CreateNewLabels(state *releaser.State) (*logging.ProgressLogging, func() string) {
 	pl := &logging.ProgressLogging{
 		TotalSteps: 5,
 	}
@@ -47,12 +47,12 @@ func CreateBackportToLabel(state *releaser.State) (*logging.ProgressLogging, fun
 		github.CreateLabel(state.VitessRelease.Repo, labelBaseBranch, backportToLabelColor, backportToLabelDesc+state.VitessRelease.BaseReleaseBranch)
 
 		// Let's use the base branch for the link as that label will also match the label of the rc branch
-		labelURL := fmt.Sprintf("https://github.com/%s/labels?q=Backport+to%%3A+%s", state.VitessRelease.Repo, state.VitessRelease.BaseReleaseBranch)
+		labelURL := fmt.Sprintf("https://github.com/%s/labels?q=%s", state.VitessRelease.Repo, state.VitessRelease.BaseReleaseBranch)
 		pl.NewStepf("Label created, see: %s", labelURL)
 
 		pl.NewStepf("Update Issue %s on GitHub", state.IssueLink)
-		state.Issue.CreateBackportToLabel.Done = true
-		state.Issue.CreateBackportToLabel.URL = labelURL
+		state.Issue.CreateNewLabels.Done = true
+		state.Issue.CreateNewLabels.URL = labelURL
 		_, fn := state.UploadIssue()
 		issueLink := fn()
 		pl.NewStepf("Issue updated, see: %s", issueLink)

--- a/go/releaser/code_freeze/create_new_labels.go
+++ b/go/releaser/code_freeze/create_new_labels.go
@@ -25,6 +25,10 @@ import (
 )
 
 const (
+	releaseBlockerLabelName  = "Release Blocker: "
+	releaseBlockerLabelColor = "B60205"
+	releaseBlockerLabelDesc  = "This item blocks the release on branch "
+
 	backportToLabelName  = "Backport to: "
 	backportToLabelColor = "D4C5F9"
 	backportToLabelDesc  = "Needs to be backport to "
@@ -32,7 +36,7 @@ const (
 
 func CreateNewLabels(state *releaser.State) (*logging.ProgressLogging, func() string) {
 	pl := &logging.ProgressLogging{
-		TotalSteps: 5,
+		TotalSteps: 6,
 	}
 
 	return pl, func() string {
@@ -45,6 +49,10 @@ func CreateNewLabels(state *releaser.State) (*logging.ProgressLogging, func() st
 		labelBaseBranch := backportToLabelName + state.VitessRelease.BaseReleaseBranch
 		pl.NewStepf("Creating '%s' label", labelBaseBranch)
 		github.CreateLabel(state.VitessRelease.Repo, labelBaseBranch, backportToLabelColor, backportToLabelDesc+state.VitessRelease.BaseReleaseBranch)
+
+		releaseBlockerLabel := releaseBlockerLabelName + state.VitessRelease.BaseReleaseBranch
+		pl.NewStepf("Creating '%s' label", releaseBlockerLabel)
+		github.CreateLabel(state.VitessRelease.Repo, releaseBlockerLabel, releaseBlockerLabelColor, releaseBlockerLabelDesc+state.VitessRelease.BaseReleaseBranch)
 
 		// Let's use the base branch for the link as that label will also match the label of the rc branch
 		labelURL := fmt.Sprintf("https://github.com/%s/labels?q=%s", state.VitessRelease.Repo, state.VitessRelease.BaseReleaseBranch)

--- a/go/releaser/issue.go
+++ b/go/releaser/issue.go
@@ -36,7 +36,7 @@ const (
 	stateReadingBackport
 	stateReadingReleaseBlockerIssue
 	stateReadingCodeFreezeItem
-	stateReadingCreateBackportLabelItem
+	stateReadingCreateNewLabelsItem
 	stateReadingUpdateSnapshotOnMainItem
 	stateReadingCreateReleasePRItem
 	stateReadingNewMilestoneItem
@@ -70,7 +70,7 @@ const (
 	// Pre-Release
 	codeFreezeItem                = "Code Freeze."
 	copyBranchProtectionRulesItem = "Copy branch protection rules."
-	createBackportToLabelItem     = "Create the Backport to labels."
+	createNewLabelsItem           = "Create new labels."
 	updateSnapshotOnMainItem      = "Update the SNAPSHOT version on main."
 	createReleasePRItem           = "Create Release PR."
 	newMilestoneItem              = "Create new GitHub Milestone."
@@ -140,7 +140,7 @@ type (
 		// Pre-Release
 		CodeFreeze                   ItemWithLink
 		CopyBranchProtectionRules    bool
-		CreateBackportToLabel        ItemWithLink
+		CreateNewLabels              ItemWithLink
 		UpdateSnapshotOnMain         ItemWithLink
 		CreateReleasePR              ItemWithLink
 		NewGitHubMilestone           ItemWithLink
@@ -215,9 +215,9 @@ const (
 {{- end }}
 {{- if eq .RC 1 }}
 - [{{fmtStatus .CopyBranchProtectionRules}}] Copy branch protection rules.
-- [{{fmtStatus .CreateBackportToLabel.Done}}] Create the Backport to labels.
-{{- if .CreateBackportToLabel.URL }}
-  - {{ .CreateBackportToLabel.URL }}
+- [{{fmtStatus .CreateNewLabels.Done}}] Create new labels.
+{{- if .CreateNewLabels.URL }}
+  - {{ .CreateNewLabels.URL }}
 {{- end }}
 - [{{fmtStatus .UpdateSnapshotOnMain.Done}}] Update the SNAPSHOT version on main.
 {{- if .UpdateSnapshotOnMain.URL }}
@@ -411,10 +411,10 @@ func (s *State) LoadIssue() {
 				}
 			case strings.Contains(line, copyBranchProtectionRulesItem):
 				newIssue.CopyBranchProtectionRules = strings.HasPrefix(line, markdownItemDone)
-			case strings.Contains(line, createBackportToLabelItem):
-				newIssue.CreateBackportToLabel.Done = strings.HasPrefix(line, markdownItemDone)
+			case strings.Contains(line, createNewLabelsItem):
+				newIssue.CreateNewLabels.Done = strings.HasPrefix(line, markdownItemDone)
 				if isNextLineAList(lines, i) {
-					st = stateReadingCreateBackportLabelItem
+					st = stateReadingCreateNewLabelsItem
 				}
 			case strings.Contains(line, updateSnapshotOnMainItem):
 				newIssue.UpdateSnapshotOnMain.Done = strings.HasPrefix(line, markdownItemDone)
@@ -514,8 +514,8 @@ func (s *State) LoadIssue() {
 			newIssue.ReleaseBlocker.Items = append(newIssue.ReleaseBlocker.Items, handleNewListItem(lines, i, &st))
 		case stateReadingCodeFreezeItem:
 			newIssue.CodeFreeze.URL = handleSingleTextItem(line, &st)
-		case stateReadingCreateBackportLabelItem:
-			newIssue.CreateBackportToLabel.URL = handleSingleTextItem(line, &st)
+		case stateReadingCreateNewLabelsItem:
+			newIssue.CreateNewLabels.URL = handleSingleTextItem(line, &st)
 		case stateReadingUpdateSnapshotOnMainItem:
 			newIssue.UpdateSnapshotOnMain.URL = handleSingleTextItem(line, &st)
 		case stateReadingCreateReleasePRItem:

--- a/go/releaser/steps/steps.go
+++ b/go/releaser/steps/steps.go
@@ -31,7 +31,7 @@ const (
 	// Pre-Release
 	CodeFreeze                   = "Code Freeze"
 	CopyBranchProtectionRules    = "Copy branch protection rules"
-	CreateBackportToLabel        = "Create Backport To Label"
+	CreateNewLabels              = "Create new labels"
 	UpdateSnapshotOnMain         = "Update SNAPSHOT on main"
 	CreateReleasePR              = "Create Release PR"
 	CreateMilestone              = "Create Milestone"


### PR DESCRIPTION
Until now the creation of the release blocker label was often forgotten. Now it is done automatically by the tool at the same time as creating the two backport to labels.