### PR TITLE
Fix workflow links for < v20 release

### DIFF
--- a/go/releaser/release/docker.go
+++ b/go/releaser/release/docker.go
@@ -29,8 +29,8 @@ func CheckDockerMessage(majorRelease int, repo string) []string {
 	// Hack: versions < v20 and versions >= v20 use different GitHub Actions workflows to build the Docker images.
 	if majorRelease < 20 {
 		msg = append(msg,
-			fmt.Sprintf("\t- https://github.com/%s/actions/workflows/docker_build_old_base.yml", repo),
-			fmt.Sprintf("\t- https://github.com/%s/actions/workflows/docker_build_old_lite.yml", repo),
+			fmt.Sprintf("\t- https://github.com/%s/actions/workflows/docker_build_base.yml", repo),
+			fmt.Sprintf("\t- https://github.com/%s/actions/workflows/docker_build_lite.yml", repo),
 		)
 	} else {
 		msg = append(msg, fmt.Sprintf("\t- https://github.com/%s/actions/workflows/docker_build_images.yml", repo))


### PR DESCRIPTION
While working on https://github.com/vitessio/vitess/pull/16196 I realized that we do not actually used the two workflows (`docker_build_old_base.yml` and `docker_build_old_lite.yml`) which I linked to in a previous PR #99. I am reverting that change to keep using the original workflow names.