### PR TITLE
Enhance the description of the manual steps (website docs and vtop)

### DIFF
--- a/go/interactive/release/vtop_manual_update.go
+++ b/go/interactive/release/vtop_manual_update.go
@@ -66,6 +66,6 @@ func vtopManualUpdateUpdate(mi *ui.MenuItem, msg tea.Msg) (*ui.MenuItem, tea.Cmd
 
 func vtopManualUpdateAct(mi *ui.MenuItem) (*ui.MenuItem, tea.Cmd) {
 	return mi, func() tea.Msg {
-		return vtopManualUpdateMsg(release.VtopManualUpdateMessage(mi.State.VtOpRelease.IsLatestRelease))
+		return vtopManualUpdateMsg(release.VtopManualUpdateMessage(mi.State))
 	}
 }

--- a/go/releaser/release/vtop_manual_update.go
+++ b/go/releaser/release/vtop_manual_update.go
@@ -16,21 +16,69 @@ limitations under the License.
 
 package release
 
-func VtopManualUpdateMessage(latest bool) []string {
-	msg := []string{
-		"On the release branch:",
-		"\t- The 'upgrade_test.sh', 'backup_restore_test.sh' and 'vtorc_vtadmin_test.sh' files must be updated with the proper release increment.",
-		"\t- Change the 'verifyVtGateVersion' function calls to use the proper version (current version being released and latest previous version (only used in 'upgrade_test.sh')).",
+import (
+	"fmt"
+	"strings"
+
+	"vitess.io/vitess-releaser/go/releaser"
+)
+
+func VtopManualUpdateMessage(state *releaser.State) []string {
+	var urlVtopReleasePRMsg string
+	var vtopHeadReleaseBranch string
+
+	for _, url := range state.Issue.VtopCreateReleasePR.URLs {
+		// In VtopCreateReleasePR there are usually two links: one to the release page and another to the release PR.
+		// We are trying to find the URL that links to a PR page.
+		if strings.Contains(url, "/pull/") {
+			urlVtopReleasePRMsg = url
+			vtopHeadReleaseBranch = url
+			break
+		}
 	}
-	if latest {
+	// The steps in the 'release' section are sequential, it is therefor not possible to not have a release PR.
+	// Unless, there was a bug/issue or the release team manually modified the release issue.
+	// In which case we might fail to find the release PR, and thus defaulting to the following message:
+	if urlVtopReleasePRMsg == "" {
+		urlVtopReleasePRMsg = fmt.Sprintf("the '%s' release branch by creating a new PR", state.VtOpRelease.ReleaseBranch)
+		vtopHeadReleaseBranch = state.VtOpRelease.ReleaseBranch
+
+	}
+
+	previousVitessRelease := releaser.FindPreviousRelease(state.VitessRelease.Remote, state.VitessRelease.MajorRelease)
+
+	msg := []string{
+		"We need to make manual changes to the test files of the vitess-operator to use the newest releases.",
+		"Everything happen under the './test/endtoend/' directory.",
+		"",
+		fmt.Sprintf("Add the following changes to %s:", urlVtopReleasePRMsg),
+		fmt.Sprintf("\t- Modify the 'verifyVtGateVersion' function calls to use '%s' as the argument on the following files:", strings.ToLower(state.VitessRelease.Release)),
+		"\t\t- backup_restore_test.sh",
+		"\t\t- vtorc_vtadmin_test.sh",
+		"\t\t- backup_schedule_test.sh",
+		"",
+		"\t- In the file 'upgrade_test.sh' there are two 'verifyVtGateVersion' calls:",
+		fmt.Sprintf("\t\t- The first one must use '%s'.", previousVitessRelease),
+		fmt.Sprintf("\t\t- The second one must use '%s'.", strings.ToLower(state.VitessRelease.Release)),
+	}
+
+	nextVitessMajorRelease := releaser.FindNextMajorRelease(state.VitessRelease.MajorRelease)
+	if state.VtOpRelease.IsLatestRelease {
 		msg = append(msg, []string{
 			"",
-			"On main:",
-			"\t- The vitess/lite image tag must be changed in '101_initial_cluster.yaml'. The latest Vitess release tag must be used.",
-			"\t- We must copy the 'operator-latest.yaml' file we created during the release onto main's 'operator.yaml' file.",
-			"\t- Once copied, remove the change that adds 'imagePullPolicy: Never' and update the image: 'vitess-operator-pr:latest' to use the docker image of latest vitess-operator patch like image: planetscale/vitess-operator:v2.10.0.",
-			"\t- The 'upgrade_test.sh', 'backup_restore_test.sh' and 'vtorc_vtadmin_test.sh' files must be updated with the proper release increment.",
-			"\t- Change the 'verifyVtGateVersion' function calls to use the proper version (new snapshot Vitess version and current version being released (only used in 'upgrade_test.sh')).",
+			"Add the following changes to 'main' by creating a new PR:",
+			fmt.Sprintf("\t- In the file '101_initial_cluster.yaml', we must use 'vitess/lite:v%s'.", strings.ToLower(state.VitessRelease.Release)),
+			fmt.Sprintf("\t- Copy the 'operator-latest.yaml' file from the HEAD of '%s' into main's 'operator/operator.yaml'.", vtopHeadReleaseBranch),
+			"\t- Once copied, modify 'operator/operator.yaml' with the following:",
+			"\t\t- Remove the change that adds 'imagePullPolicy: Never'",
+			fmt.Sprintf("\t\t- Update the image 'vitess-operator-pr:latest' to use 'planetscale/vitess-operator:v%s'.", strings.ToLower(state.Issue.VtopRelease)),
+			fmt.Sprintf("\t- The 'verifyVtGateVersion' function calls must use '%s' as an argument on the following files:", nextVitessMajorRelease),
+			"\t\t- backup_restore_test.sh",
+			"\t\t- vtorc_vtadmin_test.sh",
+			"\t\t- backup_schedule_test.sh",
+			"\t- In the file 'upgrade_test.sh' there are two 'verifyVtGateVersion' calls:",
+			fmt.Sprintf("\t\t- The first one must use '%s'.", strings.ToLower(state.VitessRelease.Release)),
+			fmt.Sprintf("\t\t- The second one must use '%s'.", nextVitessMajorRelease),
 		}...)
 	}
 	return msg

--- a/go/releaser/release/website_docs.go
+++ b/go/releaser/release/website_docs.go
@@ -23,16 +23,22 @@ import (
 func WebsiteDocs(state *releaser.State) []string {
 	msg := []string{
 		"We want to open a Pull Request to update the documentation.",
+		"",
 		"There are several pages we want to update:",
 		"\t- https://vitess.io/docs/releases/: we must add the new release to the list with all its information and link.",
 		"\t- https://vitess.io/docs/get-started/local/: we must use the proper version increment for this guide and the proper SHA.",
-		"We must do a git checkout to the proper release branch after cloning Vitess on the following pages:",
+		"",
+		"",
+		"At the beginning of the following pages, we ask the user to clone Vitess. Please make sure we are doing a 'git checkout' to the proper branch after the 'git clone'.",
+		"For RC >= 2 and patch releases it's possible that no change is required if nothing was skipped in the previous releases.",
+		"List of pages where we must do a 'git checkout':",
 		"\t- https://vitess.io/docs/get-started/operator/#install-the-operator",
 		"\t- https://vitess.io/docs/get-started/local-mac/#install-vitess",
 		"\t- https://vitess.io/docs/get-started/local-docker/#check-out-the-vitessiovitess-repository",
 		"\t- https://vitess.io/docs/get-started/vttestserver-docker-image/#check-out-the-vitessiovitess-repository",
 	}
-	if state.Issue.RC > 0 {
+
+	if state.Issue.RC == 1 {
 		msg = append(msg, []string{
 			"",
 			"Since we are doing an RC release, we must use the ./tools/rc_release.sh script in the website repository to update the documentation even further.",

--- a/go/releaser/release/website_docs.go
+++ b/go/releaser/release/website_docs.go
@@ -11,12 +11,15 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.
+limitations under the License.®
 */
 
 package release
 
 import (
+	"fmt"
+	"strings"
+
 	"vitess.io/vitess-releaser/go/releaser"
 )
 
@@ -26,8 +29,7 @@ func WebsiteDocs(state *releaser.State) []string {
 		"",
 		"There are several pages we want to update:",
 		"\t- https://vitess.io/docs/releases/: we must add the new release to the list with all its information and link.",
-		"\t- https://vitess.io/docs/get-started/local/: we must use the proper version increment for this guide and the proper SHA.",
-		"",
+		fmt.Sprintf("\t- https://vitess.io/docs/%s.0/get-started/local/#install-vitess: we must use '%s' for the 'version' variable, and the new SHA for the 'file' variable.", state.VitessRelease.MajorRelease, strings.ToLower(state.VitessRelease.Release)),
 		"",
 		"At the beginning of the following pages, we ask the user to clone Vitess. Please make sure we are doing a 'git checkout' to the proper branch after the 'git clone'.",
 		"For RC >= 2 and patch releases it's possible that no change is required if nothing was skipped in the previous releases.",

--- a/go/releaser/vitess.go
+++ b/go/releaser/vitess.go
@@ -159,6 +159,14 @@ func FindPreviousRelease(remote, currentMajor string) string {
 	return fmt.Sprintf("%s.%s.%d", currentReleaseSlice[0], currentReleaseSlice[1], patchRelease-1)
 }
 
+func FindNextMajorRelease(currentMajor string) string {
+	majorNb, err := strconv.Atoi(currentMajor)
+	if err != nil {
+		utils.LogPanic(err, "failed to convert the CLI major release argument to an int (%s)", currentMajor)
+	}
+	return fmt.Sprintf("%d.0.0", majorNb+1)
+}
+
 func getCurrentReleaseVitess() string {
 	// Execute the following command to find the version from the `version.go` file:
 	// sed -n 's/.*versionName.*\"\([[:digit:]\.]*\).*\"/\1/p' ./go/vt/servenv/version.go


### PR DESCRIPTION
This PR modifies the text of the manual steps (website docs update and vtop tests update) with something that is more clear and easier to understand. The actual content that has to be written was inserted in the text, so no need to guess what has to be updated.

**Vtop when doing v20.0.0-rc1 release:**
<img width="924" alt="image" src="https://github.com/vitessio/vitess-releaser/assets/35779988/fd465980-db1b-4e42-9cd9-70ef03c387b1">

**Website docs when doing v20.0.0-rc1 release:**
<img width="1325" alt="image" src="https://github.com/vitessio/vitess-releaser/assets/35779988/7c22a5cb-5b19-4101-8c69-34a5c693c891">
