### PR TITLE
Fix typo in the compatibility table step

### DIFF
--- a/go/releaser/pre_release/vtop_update_compatibility_table.go
+++ b/go/releaser/pre_release/vtop_update_compatibility_table.go
@@ -25,7 +25,7 @@ import (
 func VtopUpdateCompatibilityTable(state *releaser.State) []string {
 	return []string{
 		fmt.Sprintf("You open a Pull Request that updates the compatibility table found in the README of https://github.com/%s", state.VtOpRelease.Repo),
-		fmt.Sprintf("Add a new row before the last row. This new row should include the v%s.* vitess-operator release and the v%s.0.*, along with the matching K8S version.", state.VtOpRelease.Release, state.VitessRelease.MajorRelease),
+		fmt.Sprintf("Add a new row before the last row. This new row should include the v%s vitess-operator release and the v%s.0.*, along with the matching K8S version.", state.VtOpRelease.Release, state.VitessRelease.MajorRelease),
 		fmt.Sprintf("Once the Pull Request, you may bypass the branch protection rules by changing the settings in https://github.com/%s/settings/branches", state.VtOpRelease.Repo),
 	}
 }


### PR DESCRIPTION
**Before**
![image](https://github.com/vitessio/vitess-releaser/assets/35779988/aa2deae7-6280-4967-b97a-8f9f55df2231)

**After**
![image](https://github.com/vitessio/vitess-releaser/assets/35779988/96cccfc3-71a5-42ae-90d0-7c17e6c15c1e)
