### PR TITLE
Move PRs to newer milestone when doing RC-1

### DIFF
--- a/go/releaser/code_freeze/milestone.go
+++ b/go/releaser/code_freeze/milestone.go
@@ -29,6 +29,11 @@ func NewMilestone(state *releaser.State) (*logging.ProgressLogging, func() strin
 		TotalSteps: 5,
 	}
 
+	// Two extra steps if we are doing an RC-1 release
+	if state.Issue.RC == 1 {
+		pl.TotalSteps += 2
+	}
+
 	return pl, func() string {
 		var link string
 		defer func() {
@@ -60,6 +65,29 @@ func NewMilestone(state *releaser.State) (*logging.ProgressLogging, func() strin
 		pl.NewStepf("Creating Milestone %s on GitHub", newMilestone)
 		link = github.CreateNewMilestone(state.VitessRelease.Repo, newMilestone)
 		pl.NewStepf("New Milestone %s created: %s", newMilestone, link)
+
+		// Let's assume we release v20.0.0, the current milestone is v20.0.0, and new milestone which we
+		// just created is v21.0.0:
+		//
+		// During the RC-1, we want to move all opened PRs from the v20.0.0 milestone to the v21.0.0 milestone.
+		// All the PRs that are still opened on the v20.0.0 milestone are based on main, and thus need to be
+		// assigned the new milestone for main: v21.0.0. We might decide to backport an opened PR to the release
+		// branch, in which case GitHub Actions will assign the v20.0.0 milestone to the backport.
+		//
+		// This only applies to RC-1 releases. For patch releases, since the branch is frozen, the risk of
+		// merging a PR in a release that don't match the milestone is very slim.
+		if state.Issue.RC == 1 {
+			currentMilestone := fmt.Sprintf("v%s", releaser.RemoveRCFromReleaseTitle(state.VitessRelease.Release))
+			pl.NewStepf("Get opened Pull Requests for Milestone %s", currentMilestone)
+			prs := github.GetOpenedPRsByMilestone(state.VitessRelease.Repo, currentMilestone)
+
+			if len(prs) > 0 {
+				pl.NewStepf("Move %d Pull Requests to the %s Milestone", len(prs), newMilestone)
+				github.AssignMilestoneToPRs(state.VitessRelease.Repo, newMilestone, prs)
+			} else {
+				pl.NewStepf("No opened Pull Request found for Milestone %s, nothing to move", currentMilestone)
+			}
+		}
 		return link
 	}
 }


### PR DESCRIPTION
During RC-1's code freeze, we create the new release branch and a new milestone (i.e. `v21.0.0`), however we were not moving the PRs from the previous milestone (`v20.0.0`), into the new one (`v21.0.0`). Meaning that we had PRs on the `main` branch that were still assigned to the `v20.0.0` milestone although these specific PRs were never going to make it to the `v20.0.0` release (maybe they would have thanks to backport, but that does not matter).

Eventually during the release step of GA, we migrate all the opened PRs from the `v20.0.0` milestone to the new `v21.0.0` milestone, but that happens too late already.

This PR fixes this issue by migrating all opened PRs from the current to the next milestone during RC-1's code freeze.