### PR TITLE
Prevent Golang mismatch between vitess and vtop

### DIFF
--- a/go/interactive/pre_release/vtop_update_golang.go
+++ b/go/interactive/pre_release/vtop_update_golang.go
@@ -27,6 +27,10 @@ import (
 	"vitess.io/vitess-releaser/go/releaser/pre_release"
 )
 
+// This step prevents any mismatch of the Golang version between Vitess and Vitess-Operator.
+// Ideally the Golang upgrade should be done on Vitess-Operator at the same time as they are
+// done on Vitess, so this step is just a safeguard to ensure the release will build nicely.
+
 func VtopUpdateGolangMenuItem(ctx context.Context) *ui.MenuItem {
 	state := releaser.UnwrapState(ctx)
 	act := vtopUpdateGolangAct

--- a/go/releaser/pre_release/vtop_update_golang.go
+++ b/go/releaser/pre_release/vtop_update_golang.go
@@ -116,7 +116,7 @@ func VtopUpdateGolang(state *releaser.State) (*logging.ProgressLogging, func() s
 		pl.NewStepf("Create Pull Request")
 		pr := github.PR{
 			Title:  goUpdatePRName,
-			Body:   fmt.Sprintf("This Pull Request update the Golang version to %s.", vitessGoVersion.String()),
+			Body:   fmt.Sprintf("This Pull Request updates the Golang version to %s.", vitessGoVersion.String()),
 			Branch: newBranchName,
 			Base:   state.VtOpRelease.ReleaseBranch,
 		}


### PR DESCRIPTION
The `Update Go version in vitess-operator` step (pre-release) used to only update the Golang version used in vtop if vtop was behind by at least 1 golang major version. Since we recently changed vitess' go mod, we must be using the proper Golang version in vtop's test and docker images at all time to ensure that the tests are passing. This PR changes the mechanism and always make sure that both repositories are on the exact same Golang version, if not a PR is automatically created to update the Golang version of vtop.

In this PR I am also adding some code to change the Golang version in the buildkite pipeline, which was missed before.

**Testing:**

https://github.com/frouioui/vitess/issues/364 is my testing release issue, and when running the step I end up with a new PR to update the Go version of my vtop: https://github.com/frouioui/vitess-operator/pull/26