### PR TITLE
Ensure vitess-operator image is correctly built

### DIFF
--- a/go/interactive/menu_item_constructors.go
+++ b/go/interactive/menu_item_constructors.go
@@ -98,7 +98,7 @@ func dockerImagesItem(ctx context.Context) *ui.MenuItem {
 	state := releaser.UnwrapState(ctx)
 	return newBooleanMenu(
 		ctx,
-		release.CheckDockerMessage(state.VitessRelease.MajorReleaseNb, state.VitessRelease.Repo),
+		release.CheckDockerMessage(state.VitessRelease.MajorReleaseNb, state.VitessRelease.Repo, state.VtOpRelease.Repo),
 		steps.DockerImages,
 		func() { state.Issue.DockerImages = !state.Issue.DockerImages },
 		state.Issue.DockerImages,

--- a/go/releaser/release/docker.go
+++ b/go/releaser/release/docker.go
@@ -18,7 +18,7 @@ package release
 
 import "fmt"
 
-func CheckDockerMessage(majorRelease int, repo string) []string {
+func CheckDockerMessage(majorRelease int, repo string, vtopRepo string) []string {
 	msg := []string{
 		"Make sure the Docker Images are being built by GitHub Actions.",
 		"This can be done by visiting the following links, our new release should appear in either green (done) or yellow (building / pending build):",
@@ -38,6 +38,17 @@ func CheckDockerMessage(majorRelease int, repo string) []string {
 	} else {
 		// this links to the newer GitHub Actions workflow that was introduced in v21 by https://github.com/vitessio/vitess/pull/16339
 		msg = append(msg, fmt.Sprintf("\t- https://github.com/%s/vitess/actions/workflows/build_docker_images.yml", repo))
+	}
+
+	if vtopRepo != "" {
+		msg = append(msg, []string{
+			"",
+			"",
+			"Please also make sure that the vitess-operator image has been built by DockerHub.",
+			"",
+			fmt.Sprintf("\t- https://hub.docker.com/repository/docker/%s/builds", vtopRepo),
+			"",
+		}...)
 	}
 
 	return msg


### PR DESCRIPTION
This PR changes the "Check Docker" step to add a DockerHub link enabling the release lead to check whether the vitess-operator Docker Image has been correctly built.