### PR TITLE
Improve error logging

### DIFF
--- a/go/cmd/cmd.go
+++ b/go/cmd/cmd.go
@@ -77,7 +77,7 @@ func init() {
 
 	err := cobra.MarkFlagRequired(rootCmd.PersistentFlags(), flags.MajorRelease)
 	if err != nil {
-		panic(err)
+		utils.BailOutE(err)
 	}
 }
 
@@ -88,7 +88,7 @@ func Execute() {
 		os.Exit(0)
 	}
 	if err != nil {
-		panic(err)
+		utils.BailOutE(err)
 	}
 
 	if version {
@@ -210,7 +210,7 @@ func setUpIssueDate(s *releaser.State) {
 	}
 	parsedReleaseDate, err := time.Parse(time.DateOnly, releaseDate)
 	if err != nil {
-		panic(err)
+		utils.BailOutE(err)
 	}
 	s.Issue.Date = parsedReleaseDate
 }

--- a/go/cmd/cmd.go
+++ b/go/cmd/cmd.go
@@ -149,12 +149,12 @@ func setUpVitessReleaseInformation(s *releaser.State, repo string, rc int) (rele
 	// if we want to do an RC-1 release and the branch is different from `main`, something is wrong
 	// and if we want to do an >= RC-2 release, the release as to be the latest AKA on the latest release branch
 	if rcIncrement >= 1 && !isLatestRelease {
-		utils.LogPanic(nil, "wanted: RC %d but release branch was %s, latest release was %v and is from main is %v", rcIncrement, releaseBranch, isLatestRelease, isFromMain)
+		utils.BailOut(nil, "wanted: RC %d but release branch was %s, latest release was %v and is from main is %v", rcIncrement, releaseBranch, isLatestRelease, isFromMain)
 	}
 
 	majorReleaseNb, err := strconv.Atoi(releaseVersion)
 	if err != nil {
-		utils.LogPanic(err, "could not parse the release version")
+		utils.BailOut(err, "could not parse the release version")
 	}
 
 	vitessRelease := releaser.ReleaseInformation{

--- a/go/releaser/code_freeze/code_freeze.go
+++ b/go/releaser/code_freeze/code_freeze.go
@@ -158,7 +158,7 @@ func CodeFreeze(state *releaser.State) (*logging.ProgressLogging, func() string)
 func isCurrentBranchFrozen() bool {
 	b, err := os.ReadFile(codeFreezeWorkflowFile)
 	if err != nil {
-		utils.LogPanic(err, "failed to read file %s", codeFreezeWorkflowFile)
+		utils.BailOut(err, "failed to read file %s", codeFreezeWorkflowFile)
 	}
 	str := string(b)
 	return strings.Contains(str, "exit 1")

--- a/go/releaser/git/git.go
+++ b/go/releaser/git/git.go
@@ -54,7 +54,7 @@ func CreateBranchAndCheckout(branch, base string) error {
 		if strings.Contains(out, fmt.Sprintf("a branch named '%s' already exists", branch)) {
 			return errBranchExists
 		}
-		utils.LogPanic(err, "got: %s", out)
+		utils.BailOut(err, "got: %s", out)
 	}
 	return nil
 }
@@ -82,7 +82,7 @@ func CommitAll(msg string) (empty bool) {
 		if strings.Contains(out, "nothing to commit, working tree clean") {
 			return true
 		}
-		utils.LogPanic(err, "got: %s", out)
+		utils.BailOut(err, "got: %s", out)
 	}
 	return false
 }
@@ -107,17 +107,17 @@ func FindRemoteName(repository string) string {
 
 func CorrectCleanRepo(repo string) {
 	if !checkCurrentRepo(repo + ".git") {
-		utils.LogPanic(nil, "failed to find remote %s in %s", repo, getWorkingDir())
+		utils.BailOut(nil, "failed to find remote %s in %s", repo, getWorkingDir())
 	}
 	if !cleanLocalState() {
-		utils.LogPanic(nil, "the %s repository should have a clean state", getWorkingDir())
+		utils.BailOut(nil, "the %s repository should have a clean state", getWorkingDir())
 	}
 }
 
 func getWorkingDir() string {
 	dir, err := os.Getwd()
 	if err != nil {
-		utils.LogPanic(err, "failed to find the current working dir")
+		utils.BailOut(err, "failed to find the current working dir")
 	}
 	return dir
 }
@@ -133,7 +133,7 @@ func FindNewGeneratedBranch(remote, baseBranch, branchName string) string {
 			if errors.Is(err, errBranchExists) {
 				continue
 			}
-			utils.LogPanic(err, "bug should not get here")
+			utils.BailOut(err, "bug should not get here")
 		}
 		break
 	}
@@ -146,7 +146,7 @@ func TagAndPush(remote, tag string) (exists bool) {
 		if strings.Contains(out, "already exists") {
 			return true
 		}
-		utils.LogPanic(err, "got: %s", out)
+		utils.BailOut(err, "got: %s", out)
 	}
 
 	utils.Exec("git", "push", remote, tag)

--- a/go/releaser/github/branch.go
+++ b/go/releaser/github/branch.go
@@ -144,7 +144,7 @@ func getBranchProtectionRules(repo string) fetchBranchProtectionRules {
 	var bpr fetchBranchProtectionRules
 	err := json.Unmarshal([]byte(stdOut), &bpr)
 	if err != nil {
-		utils.LogPanic(err, "failed to parse the branch protection rules")
+		utils.BailOut(err, "failed to parse the branch protection rules")
 	}
 	return bpr
 }
@@ -190,17 +190,17 @@ func transformBranchProtectionRules(bpr fetchBranchProtectionRules) updateUpdate
 func putBranchProtectionRules(ubpr updateUpdateBranchProtectionRulesPayload, repo, branch string) {
 	jsonUbpr, err := json.Marshal(ubpr)
 	if err != nil {
-		utils.LogPanic(err, "failed to marshal update branch protection rules")
+		utils.BailOut(err, "failed to marshal update branch protection rules")
 	}
 
 	f, err := os.CreateTemp("/tmp", "")
 	if err != nil {
-		utils.LogPanic(err, "failed to create a temporary file")
+		utils.BailOut(err, "failed to create a temporary file")
 	}
 
 	_, err = f.Write(jsonUbpr)
 	if err != nil {
-		utils.LogPanic(err, "failed to write update branch protection rules to the temporary file")
+		utils.BailOut(err, "failed to write update branch protection rules to the temporary file")
 	}
 
 	_ = execGh("api",

--- a/go/releaser/github/issues.go
+++ b/go/releaser/github/issues.go
@@ -31,7 +31,7 @@ func execGh(args ...string) string {
 	stdOut, stdErr, err := gh.Exec(args...)
 	if err != nil {
 		cmd := append([]string{"gh"}, strings.Join(args, " "))
-		utils.LogPanic(err, "failed to execute: %s, got: %s", strings.Join(cmd, " "), stdOut.String()+stdErr.String())
+		utils.BailOut(err, "failed to execute: %s, got: %s", strings.Join(cmd, " "), stdOut.String()+stdErr.String())
 	}
 	return stdOut.String()
 }
@@ -101,7 +101,7 @@ func GetIssueTitleAndBody(repo string, nb int) (string, string) {
 	var i Issue
 	err := json.Unmarshal([]byte(stdOut), &i)
 	if err != nil {
-		utils.LogPanic(err, "failed to parse the issue number %d, got: %s", nb, stdOut)
+		utils.BailOut(err, "failed to parse the issue number %d, got: %s", nb, stdOut)
 	}
 	return i.Title, i.Body
 }
@@ -117,7 +117,7 @@ func GetReleaseIssue(repo, release string, rcIncrement int) (string, string) {
 	var issues []map[string]string
 	err := json.Unmarshal([]byte(stdOut), &issues)
 	if err != nil {
-		utils.LogPanic(err, "failed to parse the release issue, got: %s", stdOut)
+		utils.BailOut(err, "failed to parse the release issue, got: %s", stdOut)
 	}
 
 	for _, issue := range issues {
@@ -150,7 +150,7 @@ func URLToNb(url string) int {
 	issueNbStr := url[lastIdx+1:]
 	nb, err := strconv.Atoi(issueNbStr)
 	if err != nil {
-		utils.LogPanic(err, "failed to convert the end of the GitHub URL to a number, got: %s", issueNbStr)
+		utils.BailOut(err, "failed to convert the end of the GitHub URL to a number, got: %s", issueNbStr)
 	}
 	return nb
 }
@@ -170,7 +170,7 @@ func CheckReleaseBlockerIssues(repo, majorRelease string) map[string]any {
 	var issues []Issue
 	err := json.Unmarshal([]byte(stdOut), &issues)
 	if err != nil {
-		utils.LogPanic(err, "failed to parse the release blocker issue, got: %s", stdOut)
+		utils.BailOut(err, "failed to parse the release blocker issue, got: %s", stdOut)
 	}
 
 	var mustClose []Issue
@@ -206,7 +206,7 @@ func LoadKnownIssues(repo, majorRelease string) []Issue {
 	var knownIssues []Issue
 	err := json.Unmarshal([]byte(stdOut), &knownIssues)
 	if err != nil {
-		utils.LogPanic(err, "failed to parse known issues, got: %s", stdOut)
+		utils.BailOut(err, "failed to parse known issues, got: %s", stdOut)
 	}
 	return knownIssues
 }

--- a/go/releaser/github/milestone.go
+++ b/go/releaser/github/milestone.go
@@ -43,7 +43,7 @@ func GetMilestonesByName(repo, name string) []Milestone {
 	var ms []Milestone
 	err := json.Unmarshal([]byte(str), &ms)
 	if err != nil {
-		utils.LogPanic(err, "failed to parse milestone, got: %s", str)
+		utils.BailOut(err, "failed to parse milestone, got: %s", str)
 	}
 	return ms
 }
@@ -62,7 +62,7 @@ func CreateNewMilestone(repo, name string) string {
 func CloseMilestone(repo, name string) string {
 	ms := GetMilestonesByName(repo, name)
 	if len(ms) != 1 {
-		utils.LogPanic(nil, "expected to find one milestone found %d", len(ms))
+		utils.BailOut(nil, "expected to find one milestone found %d", len(ms))
 	}
 
 	stdOut := execGh(

--- a/go/releaser/github/pr.go
+++ b/go/releaser/github/pr.go
@@ -88,7 +88,7 @@ func CheckBackportToPRs(repo, branch string) map[string]any {
 	var prs []PR
 	err := json.Unmarshal([]byte(stdOut), &prs)
 	if err != nil {
-		utils.LogPanic(err, "failed to parse backport PRs, got: %s", stdOut)
+		utils.BailOut(err, "failed to parse backport PRs, got: %s", stdOut)
 	}
 
 	var mustClose []PR
@@ -120,7 +120,7 @@ func CheckReleaseBlockerPRs(repo, majorRelease string) map[string]any {
 	var prs []PR
 	err := json.Unmarshal([]byte(stdOut), &prs)
 	if err != nil {
-		utils.LogPanic(err, "failed to parse the release blocker PRs, got: %s", stdOut)
+		utils.BailOut(err, "failed to parse the release blocker PRs, got: %s", stdOut)
 	}
 
 	var mustClose []PR
@@ -154,7 +154,7 @@ func FindPR(repo, prTitle string) (nb int, url string) {
 	var prs []PR
 	err := json.Unmarshal([]byte(stdOut), &prs)
 	if err != nil {
-		utils.LogPanic(err, "failed to parse PRs, got: %s", stdOut)
+		utils.BailOut(err, "failed to parse PRs, got: %s", stdOut)
 	}
 	for _, pr := range prs {
 		if pr.Title == prTitle {
@@ -176,7 +176,7 @@ func GetMergedPRsAndAuthorsByMilestone(repo, milestone string) (prs []PR, author
 
 	err := json.Unmarshal([]byte(stdOut), &prs)
 	if err != nil {
-		utils.LogPanic(err, "failed to parse PRs, got: %s", stdOut)
+		utils.BailOut(err, "failed to parse PRs, got: %s", stdOut)
 	}
 
 	// Get the full list of distinct PRs authors and sort them
@@ -207,7 +207,7 @@ func GetOpenedPRsByMilestone(repo, milestone string) []PR {
 	var prs []PR
 	err := json.Unmarshal([]byte(stdOut), &prs)
 	if err != nil {
-		utils.LogPanic(err, "failed to parse PRs, got: %s", stdOut)
+		utils.BailOut(err, "failed to parse PRs, got: %s", stdOut)
 	}
 	return prs
 }

--- a/go/releaser/github/release.go
+++ b/go/releaser/github/release.go
@@ -18,8 +18,8 @@ package github
 
 import (
 	"fmt"
-	"log"
 	"strings"
+	"vitess.io/vitess-releaser/go/releaser/utils"
 
 	"vitess.io/vitess-releaser/go/releaser/git"
 )
@@ -57,7 +57,7 @@ func CreateRelease(repo, tag, notesFilePath string, latest, prerelease bool) (ur
 		if strings.Contains(err.Error(), "already exists") {
 			return fmt.Sprintf("https://github.com/%s/releases/tag/%s", repo, tag)
 		}
-		log.Panic(err)
+		utils.BailOutE(err)
 	}
 	return strings.ReplaceAll(stdOut, "\n", "")
 }

--- a/go/releaser/github/user.go
+++ b/go/releaser/github/user.go
@@ -28,7 +28,7 @@ func CurrentUser() string {
 
 	err := json.Unmarshal([]byte(exec), &x)
 	if err != nil {
-		utils.LogPanic(err, "failed to parse the current user, got: %s", exec)
+		utils.BailOut(err, "failed to parse the current user, got: %s", exec)
 	}
 
 	return x["login"].(string)

--- a/go/releaser/issue.go
+++ b/go/releaser/issue.go
@@ -365,7 +365,7 @@ func (s *State) LoadIssue() {
 	if idx := strings.Index(title, "-RC"); idx != -1 {
 		rc, err := strconv.Atoi(title[idx+len("-RC"):])
 		if err != nil {
-			utils.LogPanic(err, "failed to parse the RC number from the release issue title (%s)", title)
+			utils.BailOut(err, "failed to parse the RC number from the release issue title (%s)", title)
 		}
 		newIssue.RC = rc
 	}
@@ -384,7 +384,7 @@ func (s *State) LoadIssue() {
 				nline = strings.ReplaceAll(nline, ".", "") // remove the period at the end of the line
 				parsedDate, err := time.Parse("Mon _2 Jan 2006", nline)
 				if err != nil {
-					utils.LogPanic(err, "failed to parse the date from the release issue body (%s)", nline)
+					utils.BailOut(err, "failed to parse the date from the release issue body (%s)", nline)
 				}
 				newIssue.Date = parsedDate
 			}
@@ -646,12 +646,12 @@ func (i *Issue) toString() string {
 
 	parsed, err := tmpl.Parse(releaseIssueTemplate)
 	if err != nil {
-		utils.LogPanic(err, "failed to parse the release issue template")
+		utils.BailOut(err, "failed to parse the release issue template")
 	}
 	b := bytes.NewBufferString("")
 	err = parsed.Execute(b, i)
 	if err != nil {
-		utils.LogPanic(err, "failed to execute/write the release issue template")
+		utils.BailOut(err, "failed to execute/write the release issue template")
 	}
 	return b.String()
 }

--- a/go/releaser/milestone.go
+++ b/go/releaser/milestone.go
@@ -34,7 +34,7 @@ func FindVersionAfterNextRelease(state *State) string {
 	for _, segment := range segments {
 		v, err := strconv.Atoi(segment)
 		if err != nil {
-			utils.LogPanic(err, "failed to convert release number segment to number (%s)", segment)
+			utils.BailOut(err, "failed to convert release number segment to number (%s)", segment)
 		}
 		segmentInts = append(segmentInts, v)
 	}

--- a/go/releaser/pre_release/create_release_pr.go
+++ b/go/releaser/pre_release/create_release_pr.go
@@ -161,7 +161,7 @@ func findFilesRecursive() []string {
 			return nil
 		})
 		if err != nil {
-			utils.LogPanic(err, "failed to find files recursively")
+			utils.BailOut(err, "failed to find files recursively")
 		}
 	}
 	return files

--- a/go/releaser/pre_release/release_notes.go
+++ b/go/releaser/pre_release/release_notes.go
@@ -130,7 +130,7 @@ func getSegmentOfReleaseNotesDir(version string) (prefix string, major string, p
 	rx := regexp.MustCompile(`([0-9]+)\.([0-9]+)\.([0-9]+)`)
 	versionMatch := rx.FindStringSubmatch(version)
 	if len(versionMatch) != 4 {
-		utils.LogPanic(nil, "could not parse the release version when generating the release notes")
+		utils.BailOut(nil, "could not parse the release version when generating the release notes")
 	}
 
 	majorVersion := versionMatch[1] + "." + versionMatch[2]
@@ -146,7 +146,7 @@ func generateReleaseNotes(state *releaser.State, version string) {
 
 	err := os.MkdirAll(releaseNotesPath, os.ModePerm)
 	if err != nil {
-		utils.LogPanic(err, "could not create the directory: %s", releaseNotesPath)
+		utils.BailOut(err, "could not create the directory: %s", releaseNotesPath)
 	}
 
 	releaseNotes := releaseNote{
@@ -158,7 +158,7 @@ func generateReleaseNotes(state *releaser.State, version string) {
 	// summary of the release
 	_, err = os.Stat(summaryFile)
 	if err != nil && !os.IsNotExist(err) {
-		utils.LogPanic(err, "could not stat the summary file: %s", summaryFile)
+		utils.BailOut(err, "could not stat the summary file: %s", summaryFile)
 	} else if err == nil {
 		releaseNotes.Announcement = releaseSummary(summaryFile)
 	}
@@ -195,24 +195,24 @@ func (rn *releaseNote) generate() {
 	rn.PathToChangeLogFileOnGH = fmt.Sprintf(releaseNotesPathGitHub, rn.ctx.VitessRelease.Repo) + changeLogPath
 	rnFile, err := os.OpenFile(releaseNotesPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
 	if err != nil {
-		utils.LogPanic(err, "could not open file %s", releaseNotesPath)
+		utils.BailOut(err, "could not open file %s", releaseNotesPath)
 	}
 
 	t := template.Must(template.New("release_notes").Parse(markdownTemplate))
 	err = t.ExecuteTemplate(rnFile, "release_notes", rn)
 	if err != nil {
-		utils.LogPanic(err, "could not execute the release notes template")
+		utils.BailOut(err, "could not execute the release notes template")
 	}
 
 	// Generate the changelog
 	changelogFile, err := os.OpenFile(changeLogPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
 	if err != nil {
-		utils.LogPanic(err, "could not open changelog file %s", changeLogPath)
+		utils.BailOut(err, "could not open changelog file %s", changeLogPath)
 	}
 	t = template.Must(template.New("release_notes_changelog").Parse(markdownTemplateChangelog))
 	err = t.ExecuteTemplate(changelogFile, "release_notes_changelog", rn)
 	if err != nil {
-		utils.LogPanic(err, "could not execute the changelog template")
+		utils.BailOut(err, "could not execute the changelog template")
 	}
 }
 
@@ -281,7 +281,7 @@ func createSortedPrTypeSlice(prPerType prsByType) []sortedPRType {
 func releaseSummary(summaryFile string) string {
 	contentSummary, err := os.ReadFile(summaryFile)
 	if err != nil {
-		utils.LogPanic(err, "failed to read file %s", summaryFile)
+		utils.BailOut(err, "failed to read file %s", summaryFile)
 	}
 	return string(contentSummary)
 }
@@ -292,7 +292,7 @@ func getStringForPullRequestInfos(repo string, prPerType prsByType) string {
 	t := template.Must(template.New("markdownTemplatePR").Parse(fmt.Sprintf(markdownTemplatePR, repo)))
 	buff := bytes.Buffer{}
 	if err := t.ExecuteTemplate(&buff, "markdownTemplatePR", data); err != nil {
-		utils.LogPanic(err, "failed to execute the pull request list template")
+		utils.BailOut(err, "failed to execute the pull request list template")
 	}
 	return buff.String()
 }
@@ -304,7 +304,7 @@ func getStringForKnownIssues(issues []github.Issue) string {
 	t := template.Must(template.New("markdownTemplateKnownIssues").Parse(markdownTemplateKnownIssues))
 	buff := bytes.Buffer{}
 	if err := t.ExecuteTemplate(&buff, "markdownTemplateKnownIssues", issues); err != nil {
-		utils.LogPanic(err, "failed to execute the known issues template")
+		utils.BailOut(err, "failed to execute the known issues template")
 	}
 	return buff.String()
 }

--- a/go/releaser/pre_release/vtop_bump_version_on_main.go
+++ b/go/releaser/pre_release/vtop_bump_version_on_main.go
@@ -121,6 +121,6 @@ func VtopBumpMainVersion(state *releaser.State) (*logging.ProgressLogging, func(
 func UpdateVtOpVersionGoFile(newVersion string) {
 	err := os.WriteFile(vtopVersionGoFile, []byte(fmt.Sprintf(vtopVersionGo, time.Now().Year(), newVersion)), os.ModePerm)
 	if err != nil {
-		utils.LogPanic(err, "failed to write to file %s", vtopVersionGoFile)
+		utils.BailOut(err, "failed to write to file %s", vtopVersionGoFile)
 	}
 }

--- a/go/releaser/pre_release/vtop_update_golang.go
+++ b/go/releaser/pre_release/vtop_update_golang.go
@@ -158,7 +158,7 @@ func findVtopWorkflowFiles() []string {
 		return nil
 	})
 	if err != nil {
-		utils.LogPanic(err, "failed to walk the directory %s", root)
+		utils.BailOut(err, "failed to walk the directory %s", root)
 	}
 	return files
 }
@@ -167,18 +167,18 @@ func currentGolangVersionInVitess() *version.Version {
 	buildFile := "build.env"
 	contentRaw, err := os.ReadFile(buildFile)
 	if err != nil {
-		utils.LogPanic(err, "failed to read the file %s", buildFile)
+		utils.BailOut(err, "failed to read the file %s", buildFile)
 	}
 	content := string(contentRaw)
 
 	versre := regexp.MustCompile(regexpFindGolangVersionInVitess)
 	versionStr := versre.FindStringSubmatch(content)
 	if len(versionStr) != 2 {
-		utils.LogPanic(nil, "malformatted error, got: %v", versionStr)
+		utils.BailOut(nil, "malformatted error, got: %v", versionStr)
 	}
 	v, err := version.NewVersion(versionStr[1])
 	if err != nil {
-		utils.LogPanic(err, "failed to create new version with %s", versionStr[1])
+		utils.BailOut(err, "failed to create new version with %s", versionStr[1])
 	}
 	return v
 }
@@ -187,7 +187,7 @@ func currentGolangVersionInVtop() *version.Version {
 	gomodFile := "go.mod"
 	contentRaw, err := os.ReadFile(gomodFile)
 	if err != nil {
-		utils.LogPanic(err, "failed to read file %s", gomodFile)
+		utils.BailOut(err, "failed to read file %s", gomodFile)
 	}
 	content := string(contentRaw)
 
@@ -200,10 +200,10 @@ func currentGolangVersionInVtop() *version.Version {
 		}
 		v, err := version.NewVersion(versionStr[1])
 		if err != nil {
-			utils.LogPanic(err, "failed to create new version with %s", versionStr[1])
+			utils.BailOut(err, "failed to create new version with %s", versionStr[1])
 		}
 		return v
 	}
-	utils.LogPanic(nil, "could not parse the %s", gomodFile)
+	utils.BailOut(nil, "could not parse the %s", gomodFile)
 	return nil
 }

--- a/go/releaser/release/java.go
+++ b/go/releaser/release/java.go
@@ -45,12 +45,12 @@ func JavaRelease(state *releaser.State) (*logging.ProgressLogging, func() string
 			cmd := exec.Command("/bin/sh", "-c", "eval $(gpg-agent --daemon --no-grab --write-env-file $HOME/.gpg-agent-info); export GPG_TTY=$(tty); export GPG_AGENT_INFO; export MAVEN_OPTS=\"--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED\"; mvn clean deploy -P release -DskipTests;")
 			pwd, err := os.Getwd()
 			if err != nil {
-				utils.LogPanic(err, "failed to get current working directory")
+				utils.BailOut(err, "failed to get current working directory")
 			}
 			cmd.Dir = path.Join(pwd, "/java")
 			out, err := cmd.CombinedOutput()
 			if err != nil {
-				utils.LogPanic(err, "failed to execute: %s, got: %s", cmd.String(), string(out))
+				utils.BailOut(err, "failed to execute: %s, got: %s", cmd.String(), string(out))
 			}
 		} else {
 			pl.NewStepf("Running in non-live mode, skipping the actual Java release.")

--- a/go/releaser/release/merge_pr.go
+++ b/go/releaser/release/merge_pr.go
@@ -37,7 +37,7 @@ func MergeReleasePR(state *releaser.State) (*logging.ProgressLogging, func() str
 		url := state.Issue.CreateReleasePR.URL
 		nb, err := strconv.Atoi(url[strings.LastIndex(url, "/")+1:])
 		if err != nil {
-			utils.LogPanic(err, "failed to parse the PR number from GitHub URL: %s", url)
+			utils.BailOut(err, "failed to parse the PR number from GitHub URL: %s", url)
 		}
 
 		pl.NewStepf("Waiting for %s to be merged", url)

--- a/go/releaser/release/tag_release.go
+++ b/go/releaser/release/tag_release.go
@@ -51,7 +51,7 @@ func TagRelease(state *releaser.State) (*logging.ProgressLogging, func() string)
 		// i.e. if we release v17.0.1, we also want to tag: v0.17.1
 		nextReleaseSplit := strings.Split(lowerCaseRelease, ".")
 		if len(nextReleaseSplit) != 3 {
-			utils.LogPanic(nil, "%s was not formated x.x.x", state.VitessRelease.Release)
+			utils.BailOut(nil, "%s was not formated x.x.x", state.VitessRelease.Release)
 		}
 		gdocGitTag := fmt.Sprintf("v0.%s.%s", nextReleaseSplit[0], nextReleaseSplit[2])
 		git.TagAndPush(state.VitessRelease.Remote, gdocGitTag)

--- a/go/releaser/release/vtop_create_release_pr.go
+++ b/go/releaser/release/vtop_create_release_pr.go
@@ -201,7 +201,7 @@ func updateVitessDeps(state *releaser.State) {
 
 	currentReleaseSlice := strings.Split(state.VitessRelease.Release, ".")
 	if len(currentReleaseSlice) != 3 {
-		utils.LogPanic(nil, "could not parse the version.go in vitessio/vitess, output: %s", state.VitessRelease.Release)
+		utils.BailOut(nil, "could not parse the version.go in vitessio/vitess, output: %s", state.VitessRelease.Release)
 	}
 
 	utils.Exec("go", "get", "-u", fmt.Sprintf("vitess.io/vitess@v0.%s.%s", currentReleaseSlice[0], strings.ToLower(currentReleaseSlice[2])))
@@ -264,7 +264,7 @@ func vtopTestFiles() []string {
 		return nil
 	})
 	if err != nil {
-		utils.LogPanic(err, "failed to walk directory %s", root)
+		utils.BailOut(err, "failed to walk directory %s", root)
 	}
 	return files
 }
@@ -275,14 +275,14 @@ func findNextVtOpVersion(version string, rc int) string {
 	}
 	segments := strings.Split(version, ".")
 	if len(segments) != 3 {
-		utils.LogPanic(nil, "expected three segments when looking at the vtop version, got: %s", version)
+		utils.BailOut(nil, "expected three segments when looking at the vtop version, got: %s", version)
 	}
 
 	segmentInts := make([]int, 0, len(segments))
 	for _, segment := range segments {
 		v, err := strconv.Atoi(segment)
 		if err != nil {
-			utils.LogPanic(err, "failed to convert segment of the vtop version to an int: %s", segment)
+			utils.BailOut(err, "failed to convert segment of the vtop version to an int: %s", segment)
 		}
 		segmentInts = append(segmentInts, v)
 	}

--- a/go/releaser/state.go
+++ b/go/releaser/state.go
@@ -90,11 +90,11 @@ func (s *State) GoToVtOp() {
 func changeDir(p string) {
 	cwd, err := syscall.Getwd()
 	if err != nil {
-		utils.LogPanic(err, "failed to get current working directory")
+		utils.BailOut(err, "failed to get current working directory")
 	}
 	p = path.Join(cwd, p)
 	err = syscall.Chdir(p)
 	if err != nil {
-		utils.LogPanic(err, "failed to change directory to %s", p)
+		utils.BailOut(err, "failed to change directory to %s", p)
 	}
 }

--- a/go/releaser/utils/utils.go
+++ b/go/releaser/utils/utils.go
@@ -28,8 +28,9 @@ func BailOut(err error, msg string, args ...interface{}) {
 	fullMsg := fmt.Sprintf(msg, args...)
 	if err == nil {
 		log.Println(fullMsg)
+	} else {
+		log.Println(err.Error(), "\n", fullMsg, "\n", string(debug.Stack()))
 	}
-	log.Println(err, "\n", fullMsg, "\n", debug.Stack())
 	os.Exit(1)
 }
 

--- a/go/releaser/utils/utils.go
+++ b/go/releaser/utils/utils.go
@@ -19,22 +19,25 @@ package utils
 import (
 	"fmt"
 	"log"
+	"os"
 	"os/exec"
+	"runtime/debug"
 )
 
-func LogPanic(err error, msg string, args ...interface{}) {
+func BailOut(err error, msg string, args ...interface{}) {
 	fullMsg := fmt.Sprintf(msg, args...)
 	if err == nil {
-		log.Panic(fullMsg)
+		log.Println(fullMsg)
 	}
-	log.Panicf("%v: %s", err, fullMsg)
+	log.Println(err, "\n", fullMsg, "\n", debug.Stack())
+	os.Exit(1)
 }
 
 func Exec(cmd string, args ...string) string {
 	command := exec.Command(cmd, args...)
 	out, err := command.CombinedOutput()
 	if err != nil {
-		LogPanic(err, "failed to execute: %s, got: %s", command.String(), string(out))
+		BailOut(err, "failed to execute: %s, got: %s", command.String(), string(out))
 	}
 	return string(out)
 }

--- a/go/releaser/utils/utils.go
+++ b/go/releaser/utils/utils.go
@@ -33,6 +33,11 @@ func BailOut(err error, msg string, args ...interface{}) {
 	os.Exit(1)
 }
 
+func BailOutE(err error) {
+	log.Println(err, "\n", debug.Stack())
+	os.Exit(1)
+}
+
 func Exec(cmd string, args ...string) string {
 	command := exec.Command(cmd, args...)
 	out, err := command.CombinedOutput()

--- a/go/releaser/vitess.go
+++ b/go/releaser/vitess.go
@@ -88,11 +88,11 @@ func FindNextRelease(remote, majorRelease string, isVtOp bool, rc int) (currentR
 		if len(mainMajorParts) == 2 && len(majorParts) == 2 {
 			mainMajorNb, err := strconv.Atoi(mainMajorParts[1])
 			if err != nil {
-				utils.LogPanic(err, "failed to convert main minor release increment to an int (%s)", mainMajorParts[1])
+				utils.BailOut(err, "failed to convert main minor release increment to an int (%s)", mainMajorParts[1])
 			}
 			majorNb, err := strconv.Atoi(majorParts[1])
 			if err != nil {
-				utils.LogPanic(err, "failed to convert CLI release argument's minor release increment to an int (%s)", majorParts[1])
+				utils.BailOut(err, "failed to convert CLI release argument's minor release increment to an int (%s)", majorParts[1])
 			}
 			if rc > 0 && mainMajorNb == majorNb || mainMajorNb+1 == majorNb {
 				return fmt.Sprintf("%s.%d.0", mainMajorParts[0], majorNb), releaseBranchName, true, true, ga
@@ -112,20 +112,20 @@ func FindNextRelease(remote, majorRelease string, isVtOp bool, rc int) (currentR
 	// if the current release and the wanted release are different, it means there is an
 	// error, we were not able to find the proper branch / corresponding release
 	if major != majorRelease {
-		utils.LogPanic(nil, "on branch '%s', could not find the corresponding major release '%s'", releaseBranchName, majorRelease)
+		utils.BailOut(nil, "on branch '%s', could not find the corresponding major release '%s'", releaseBranchName, majorRelease)
 	}
 
 	mainMajorNb, err := strconv.ParseFloat(mainMajor, 64)
 	if err != nil {
-		utils.LogPanic(err, "could not parse main branch major release number as a float (%s)", mainMajor)
+		utils.BailOut(err, "could not parse main branch major release number as a float (%s)", mainMajor)
 	}
 	majorNb, err := strconv.ParseFloat(major, 64)
 	if err != nil {
-		utils.LogPanic(err, "could not parse CLI major release argument as a float (%s)", major)
+		utils.BailOut(err, "could not parse CLI major release argument as a float (%s)", major)
 	}
 	releaseParts := strings.Split(currentRelease, ".")
 	if len(releaseParts) != 3 {
-		utils.LogPanic(nil, "could not parse the found release: %s", currentRelease)
+		utils.BailOut(nil, "could not parse the found release: %s", currentRelease)
 	}
 	isLatest := mainMajorNb-1 == majorNb
 	ga = rc == 0 && releaseParts[1] == "0" && releaseParts[2] == "0"
@@ -139,7 +139,7 @@ func FindNextRelease(remote, majorRelease string, isVtOp bool, rc int) (currentR
 func FindPreviousRelease(remote, currentMajor string) string {
 	majorNb, err := strconv.Atoi(currentMajor)
 	if err != nil {
-		utils.LogPanic(err, "failed to convert the CLI major release argument to an int (%s)", currentMajor)
+		utils.BailOut(err, "failed to convert the CLI major release argument to an int (%s)", currentMajor)
 	}
 
 	previousMajor := majorNb - 1
@@ -150,11 +150,11 @@ func FindPreviousRelease(remote, currentMajor string) string {
 	currentRelease := getCurrentReleaseVitess()
 	currentReleaseSlice := strings.Split(currentRelease, ".")
 	if len(currentReleaseSlice) != 3 {
-		utils.LogPanic(nil, "could not parse the version.go in vitessio/vitess, output: %s", currentRelease)
+		utils.BailOut(nil, "could not parse the version.go in vitessio/vitess, output: %s", currentRelease)
 	}
 	patchRelease, err := strconv.Atoi(currentReleaseSlice[2])
 	if err != nil {
-		utils.LogPanic(err, "could not parse the version.go in vitessio/vitess, output: %s", currentRelease)
+		utils.BailOut(err, "could not parse the version.go in vitessio/vitess, output: %s", currentRelease)
 	}
 	return fmt.Sprintf("%s.%s.%d", currentReleaseSlice[0], currentReleaseSlice[1], patchRelease-1)
 }
@@ -162,7 +162,7 @@ func FindPreviousRelease(remote, currentMajor string) string {
 func FindNextMajorRelease(currentMajor string) string {
 	majorNb, err := strconv.Atoi(currentMajor)
 	if err != nil {
-		utils.LogPanic(err, "failed to convert the CLI major release argument to an int (%s)", currentMajor)
+		utils.BailOut(err, "failed to convert the CLI major release argument to an int (%s)", currentMajor)
 	}
 	return fmt.Sprintf("%d.0.0", majorNb+1)
 }
@@ -188,7 +188,7 @@ func releaseToMajorVitess(release string) string {
 func releaseToMajorVtOp(release string) string {
 	parts := strings.Split(release, ".")
 	if len(parts) != 3 {
-		utils.LogPanic(nil, "expected the vtop version to have format x.x.x but was %s", release)
+		utils.BailOut(nil, "expected the vtop version to have format x.x.x but was %s", release)
 	}
 	return fmt.Sprintf("%s.%s", parts[0], parts[1])
 }
@@ -196,7 +196,7 @@ func releaseToMajorVtOp(release string) string {
 func UpdateVersionGoFile(newVersion string) {
 	err := os.WriteFile(versionGoFile, []byte(fmt.Sprintf(versionGo, time.Now().Year(), newVersion)), os.ModePerm)
 	if err != nil {
-		utils.LogPanic(err, "failed to write to file %s", versionGoFile)
+		utils.BailOut(err, "failed to write to file %s", versionGoFile)
 	}
 }
 
@@ -206,11 +206,11 @@ func UpdateJavaDir(newVersion string) {
 	cmd := exec.Command("mvn", "versions:set", fmt.Sprintf("-DnewVersion=%s", newVersion))
 	pwd, err := os.Getwd()
 	if err != nil {
-		utils.LogPanic(err, "failed to get current working directory")
+		utils.BailOut(err, "failed to get current working directory")
 	}
 	cmd.Dir = path.Join(pwd, "/java")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		utils.LogPanic(err, "failed to execute: %s, got: %s", cmd.String(), string(out))
+		utils.BailOut(err, "failed to execute: %s, got: %s", cmd.String(), string(out))
 	}
 }


### PR DESCRIPTION
We used to panic on various errors in the releaser. Some stack traces are very large and maybe contain control characters, not allowing us to scroll back to the top of the error stack and needing an `stty sane` to restore the terminal.

This PR replaces panics by printing the error and the debug stack and exiting. It also handles inadvertent panics via a recover and logging.