### PR TITLE
Remove duplicated (base and real release branch) sub-steps

### DIFF
--- a/go/releaser/code_freeze/copy_branch_protection_rules.go
+++ b/go/releaser/code_freeze/copy_branch_protection_rules.go
@@ -24,7 +24,7 @@ import (
 
 func CopyBranchProtectionRules(state *releaser.State) (*logging.ProgressLogging, func() string) {
 	pl := &logging.ProgressLogging{
-		TotalSteps: 4,
+		TotalSteps: 3,
 	}
 
 	return pl, func() string {

--- a/go/releaser/code_freeze/copy_branch_protection_rules.go
+++ b/go/releaser/code_freeze/copy_branch_protection_rules.go
@@ -41,8 +41,6 @@ func CopyBranchProtectionRules(state *releaser.State) (*logging.ProgressLogging,
 			pl.NewStepf("Skipping as we are not running on vitessio/vitess.")
 			return ""
 		}
-		pl.NewStepf("Duplicating the branch protection rules for %s", state.VitessRelease.ReleaseBranch)
-		github.CopyBranchProtectionRules(state.VitessRelease.Repo, state.VitessRelease.ReleaseBranch)
 
 		pl.NewStepf("Duplicating the branch protection rules for %s", state.VitessRelease.BaseReleaseBranch)
 		github.CopyBranchProtectionRules(state.VitessRelease.Repo, state.VitessRelease.BaseReleaseBranch)

--- a/go/releaser/code_freeze/create_new_labels.go
+++ b/go/releaser/code_freeze/create_new_labels.go
@@ -36,7 +36,7 @@ const (
 
 func CreateNewLabels(state *releaser.State) (*logging.ProgressLogging, func() string) {
 	pl := &logging.ProgressLogging{
-		TotalSteps: 6,
+		TotalSteps: 5,
 	}
 
 	return pl, func() string {

--- a/go/releaser/code_freeze/create_new_labels.go
+++ b/go/releaser/code_freeze/create_new_labels.go
@@ -40,11 +40,6 @@ func CreateNewLabels(state *releaser.State) (*logging.ProgressLogging, func() st
 	}
 
 	return pl, func() string {
-		// Create the label for the rc release branch i.e. "Backport to: release-20.0-rc"
-		labelRcBranch := backportToLabelName + state.VitessRelease.ReleaseBranch
-		pl.NewStepf("Creating '%s' label", labelRcBranch)
-		github.CreateLabel(state.VitessRelease.Repo, labelRcBranch, backportToLabelColor, backportToLabelDesc+state.VitessRelease.ReleaseBranch)
-
 		// Create the label for the base release branch i.e. "Backport to: release-20.0"
 		labelBaseBranch := backportToLabelName + state.VitessRelease.BaseReleaseBranch
 		pl.NewStepf("Creating '%s' label", labelBaseBranch)


### PR DESCRIPTION
This PR is a follow up of when we removed the RC branch (i.e. `release-20.0-rc`), we still had some left over sub-steps.

Part of https://github.com/vitessio/vitess-releaser/issues/114