### PR TITLE
Move some vtop steps to code freeze

### DIFF
--- a/go/interactive/code_freeze/vtop_bump_version_on_main.go
+++ b/go/interactive/code_freeze/vtop_bump_version_on_main.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pre_release
+package code_freeze
 
 import (
 	"context"
@@ -22,43 +22,44 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"vitess.io/vitess-releaser/go/interactive/ui"
 	"vitess.io/vitess-releaser/go/releaser"
+	"vitess.io/vitess-releaser/go/releaser/code_freeze"
 	"vitess.io/vitess-releaser/go/releaser/steps"
-
-	"vitess.io/vitess-releaser/go/releaser/pre_release"
 )
 
-func VtopCreateBranchMenuItem(ctx context.Context) *ui.MenuItem {
+func VtopBumpMainVersionMenuItem(ctx context.Context) *ui.MenuItem {
 	state := releaser.UnwrapState(ctx)
-	act := vtopCreateBranchAct
-	if state.Issue.VtopCreateBranch {
+	act := vtopBumpMainVersionAct
+	if state.Issue.VtopBumpMainVersion.Done {
 		act = nil
 	}
 	return &ui.MenuItem{
 		State:  state,
-		Name:   steps.VtopCreateBranch,
+		Name:   steps.VtopBumpMainVersion,
 		Act:    act,
-		Update: vtopCreateBranchUpdate,
-		IsDone: state.Issue.VtopCreateBranch,
+		Update: vtopBumpMainVersionUpdate,
+		Info:   state.Issue.VtopBumpMainVersion.URL,
+		IsDone: state.Issue.VtopBumpMainVersion.Done,
 
 		Ignore: state.VtOpRelease.Release == "" || state.Issue.RC != 1,
 	}
 }
 
-type vtopCreateBranchUrl string
+type vtopBumpMainVersionUrl string
 
-func vtopCreateBranchUpdate(mi *ui.MenuItem, msg tea.Msg) (*ui.MenuItem, tea.Cmd) {
-	_, ok := msg.(vtopCreateBranchUrl)
+func vtopBumpMainVersionUpdate(mi *ui.MenuItem, msg tea.Msg) (*ui.MenuItem, tea.Cmd) {
+	_, ok := msg.(vtopBumpMainVersionUrl)
 	if !ok {
 		return mi, nil
 	}
 
-	mi.IsDone = mi.State.Issue.VtopCreateBranch
+	mi.IsDone = mi.State.Issue.VtopBumpMainVersion.Done
+	mi.Info = mi.State.Issue.VtopBumpMainVersion.URL
 	return mi, nil
 }
 
-func vtopCreateBranchAct(mi *ui.MenuItem) (*ui.MenuItem, tea.Cmd) {
-	pl, freeze := pre_release.VtopCreateBranch(mi.State)
+func vtopBumpMainVersionAct(mi *ui.MenuItem) (*ui.MenuItem, tea.Cmd) {
+	pl, fn := code_freeze.VtopBumpMainVersion(mi.State)
 	return mi, tea.Batch(func() tea.Msg {
-		return vtopCreateBranchUrl(freeze())
-	}, ui.PushDialog(ui.NewProgressDialog(steps.VtopCreateBranch, pl)))
+		return vtopBumpMainVersionUrl(fn())
+	}, ui.PushDialog(ui.NewProgressDialog(steps.VtopBumpMainVersion, pl)))
 }

--- a/go/interactive/code_freeze/vtop_create_branch.go
+++ b/go/interactive/code_freeze/vtop_create_branch.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pre_release
+package code_freeze
 
 import (
 	"context"
@@ -22,45 +22,42 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"vitess.io/vitess-releaser/go/interactive/ui"
 	"vitess.io/vitess-releaser/go/releaser"
+	"vitess.io/vitess-releaser/go/releaser/code_freeze"
 	"vitess.io/vitess-releaser/go/releaser/steps"
-
-	"vitess.io/vitess-releaser/go/releaser/pre_release"
 )
 
-func VtopBumpMainVersionMenuItem(ctx context.Context) *ui.MenuItem {
+func VtopCreateBranchMenuItem(ctx context.Context) *ui.MenuItem {
 	state := releaser.UnwrapState(ctx)
-	act := vtopBumpMainVersionAct
-	if state.Issue.VtopBumpMainVersion.Done {
+	act := vtopCreateBranchAct
+	if state.Issue.VtopCreateBranch {
 		act = nil
 	}
 	return &ui.MenuItem{
 		State:  state,
-		Name:   steps.VtopBumpMainVersion,
+		Name:   steps.VtopCreateBranch,
 		Act:    act,
-		Update: vtopBumpMainVersionUpdate,
-		Info:   state.Issue.VtopBumpMainVersion.URL,
-		IsDone: state.Issue.VtopBumpMainVersion.Done,
+		Update: vtopCreateBranchUpdate,
+		IsDone: state.Issue.VtopCreateBranch,
 
 		Ignore: state.VtOpRelease.Release == "" || state.Issue.RC != 1,
 	}
 }
 
-type vtopBumpMainVersionUrl string
+type vtopCreateBranchUrl string
 
-func vtopBumpMainVersionUpdate(mi *ui.MenuItem, msg tea.Msg) (*ui.MenuItem, tea.Cmd) {
-	_, ok := msg.(vtopBumpMainVersionUrl)
+func vtopCreateBranchUpdate(mi *ui.MenuItem, msg tea.Msg) (*ui.MenuItem, tea.Cmd) {
+	_, ok := msg.(vtopCreateBranchUrl)
 	if !ok {
 		return mi, nil
 	}
 
-	mi.IsDone = mi.State.Issue.VtopBumpMainVersion.Done
-	mi.Info = mi.State.Issue.VtopBumpMainVersion.URL
+	mi.IsDone = mi.State.Issue.VtopCreateBranch
 	return mi, nil
 }
 
-func vtopBumpMainVersionAct(mi *ui.MenuItem) (*ui.MenuItem, tea.Cmd) {
-	pl, fn := pre_release.VtopBumpMainVersion(mi.State)
+func vtopCreateBranchAct(mi *ui.MenuItem) (*ui.MenuItem, tea.Cmd) {
+	pl, freeze := code_freeze.VtopCreateBranch(mi.State)
 	return mi, tea.Batch(func() tea.Msg {
-		return vtopBumpMainVersionUrl(fn())
-	}, ui.PushDialog(ui.NewProgressDialog(steps.VtopBumpMainVersion, pl)))
+		return vtopCreateBranchUrl(freeze())
+	}, ui.PushDialog(ui.NewProgressDialog(steps.VtopCreateBranch, pl)))
 }

--- a/go/interactive/main_menu.go
+++ b/go/interactive/main_menu.go
@@ -19,8 +19,9 @@ package interactive
 import (
 	"context"
 	"fmt"
-	tea "github.com/charmbracelet/bubbletea"
 	"os"
+
+	tea "github.com/charmbracelet/bubbletea"
 	"vitess.io/vitess-releaser/go/interactive/code_freeze"
 	"vitess.io/vitess-releaser/go/interactive/post_release"
 	"vitess.io/vitess-releaser/go/interactive/pre_release"
@@ -54,16 +55,16 @@ func MainScreen(ctx context.Context, state *releaser.State) {
 		code_freeze.CreateNewLabelsMenuItem(ctx),
 		code_freeze.UpdateSnapshotOnMainMenuItem(ctx),
 		code_freeze.CreateMilestoneMenuItem(ctx),
+		code_freeze.VtopCreateBranchMenuItem(ctx),
+		code_freeze.VtopBumpMainVersionMenuItem(ctx),
+		vtopUpdateCompatibilityTableMenuItem(ctx),
 	)
 
 	preReleaseMenu := ui.NewMenu(
 		ctx,
 		"Pre Release",
 		pre_release.CreateReleasePRMenuItem(ctx),
-		pre_release.VtopCreateBranchMenuItem(ctx),
-		pre_release.VtopBumpMainVersionMenuItem(ctx),
 		pre_release.VtopUpdateGolangMenuItem(ctx),
-		vtopUpdateCompatibilityTableMenuItem(ctx),
 		createBlogPostPRMenuItem(ctx),
 	)
 

--- a/go/interactive/menu_item_constructors.go
+++ b/go/interactive/menu_item_constructors.go
@@ -21,8 +21,8 @@ import (
 
 	"vitess.io/vitess-releaser/go/interactive/ui"
 	"vitess.io/vitess-releaser/go/releaser"
+	"vitess.io/vitess-releaser/go/releaser/code_freeze"
 	"vitess.io/vitess-releaser/go/releaser/post_release"
-	"vitess.io/vitess-releaser/go/releaser/pre_release"
 	"vitess.io/vitess-releaser/go/releaser/prerequisite"
 	"vitess.io/vitess-releaser/go/releaser/release"
 	"vitess.io/vitess-releaser/go/releaser/steps"
@@ -65,7 +65,7 @@ func vtopUpdateCompatibilityTableMenuItem(ctx context.Context) *ui.MenuItem {
 	state := releaser.UnwrapState(ctx)
 	return newBooleanMenu(
 		ctx,
-		pre_release.VtopUpdateCompatibilityTable(state),
+		code_freeze.VtopUpdateCompatibilityTable(state),
 		steps.VtopUpdateCompatibilityTable,
 		func() { state.Issue.VtopUpdateCompatibilityTable = !state.Issue.VtopUpdateCompatibilityTable },
 		state.Issue.VtopUpdateCompatibilityTable,

--- a/go/releaser/code_freeze/vtop_bump_version_on_main.go
+++ b/go/releaser/code_freeze/vtop_bump_version_on_main.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pre_release
+package code_freeze
 
 import (
 	"fmt"

--- a/go/releaser/code_freeze/vtop_create_branch.go
+++ b/go/releaser/code_freeze/vtop_create_branch.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pre_release
+package code_freeze
 
 import (
 	"fmt"

--- a/go/releaser/code_freeze/vtop_update_compatibility_table.go
+++ b/go/releaser/code_freeze/vtop_update_compatibility_table.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pre_release
+package code_freeze
 
 import (
 	"fmt"

--- a/go/releaser/issue.go
+++ b/go/releaser/issue.go
@@ -228,6 +228,18 @@ const (
 {{- if .NewGitHubMilestone.URL }}
   - {{ .NewGitHubMilestone.URL }}
 {{- end }}
+{{- if .DoVtOp }}
+{{- if eq .RC 1 }}
+- [{{fmtStatus .VtopCreateBranch}}] Create vitess-operator release branch.
+- [{{fmtStatus .VtopBumpMainVersion.Done}}] Bump the version vitess-operator main.
+{{- if .VtopBumpMainVersion.URL }}
+  - {{ .VtopBumpMainVersion.URL }}
+{{- end }}
+{{- end }}
+{{- if eq .RC 1 }}
+- [{{fmtStatus .VtopUpdateCompatibilityTable}}] Update vitess-operator compatibility table.
+{{- end }}
+{{- end }}
 {{- end }}
 
 ### Pre-Release _(~1-3 days before)_
@@ -237,19 +249,9 @@ const (
   - {{ .CreateReleasePR.URL }}
 {{- end }}
 {{- if .DoVtOp }}
-{{- if eq .RC 1 }}
-- [{{fmtStatus .VtopCreateBranch}}] Create vitess-operator release branch.
-- [{{fmtStatus .VtopBumpMainVersion.Done}}] Bump the version vitess-operator main.
-{{- if .VtopBumpMainVersion.URL }}
-  - {{ .VtopBumpMainVersion.URL }}
-{{- end }}
-{{- end }}
 - [{{fmtStatus .VtopUpdateGolang.Done}}] Update vitess-operator Golang version.
 {{- if .VtopUpdateGolang.URL }}
   - {{ .VtopUpdateGolang.URL }}
-{{- end }}
-{{- if eq .RC 1 }}
-- [{{fmtStatus .VtopUpdateCompatibilityTable}}] Update vitess-operator compatibility table.
 {{- end }}
 {{- end }}
 {{- if .GA }}

--- a/go/releaser/release/vtop_create_release_pr.go
+++ b/go/releaser/release/vtop_create_release_pr.go
@@ -25,10 +25,10 @@ import (
 	"time"
 
 	"vitess.io/vitess-releaser/go/releaser"
+	"vitess.io/vitess-releaser/go/releaser/code_freeze"
 	"vitess.io/vitess-releaser/go/releaser/git"
 	"vitess.io/vitess-releaser/go/releaser/github"
 	"vitess.io/vitess-releaser/go/releaser/logging"
-	"vitess.io/vitess-releaser/go/releaser/pre_release"
 	"vitess.io/vitess-releaser/go/releaser/utils"
 )
 
@@ -129,7 +129,7 @@ func VtopCreateReleasePR(state *releaser.State) (*logging.ProgressLogging, func(
 
 		// 7. Update the version file of vtop
 		pl.NewStepf("Update version file to %s", lowerReleaseName)
-		pre_release.UpdateVtOpVersionGoFile(lowerReleaseName)
+		code_freeze.UpdateVtOpVersionGoFile(lowerReleaseName)
 		if !git.CommitAll(fmt.Sprintf("Update the version file to %s", lowerReleaseName)) {
 			commitCount++
 			git.Push(state.VtOpRelease.Remote, newBranchName)
@@ -157,7 +157,7 @@ func VtopCreateReleasePR(state *releaser.State) (*logging.ProgressLogging, func(
 		// 11. Figure out what is the next vtop release for this branch
 		nextRelease := findNextVtOpVersion(state.VtOpRelease.Release, state.Issue.RC)
 		pl.NewStepf("Go back to dev mode with version = %s", nextRelease)
-		pre_release.UpdateVtOpVersionGoFile(nextRelease)
+		code_freeze.UpdateVtOpVersionGoFile(nextRelease)
 		if !git.CommitAll(fmt.Sprintf("Go back to dev mode")) {
 			commitCount++
 			git.Push(state.VtOpRelease.Remote, newBranchName)

--- a/go/releaser/steps/steps.go
+++ b/go/releaser/steps/steps.go
@@ -21,24 +21,24 @@ const (
 	ReleaseIssue       = "Release Issue"
 
 	// Prerequisite
-	GeneralPrerequisite = "General"
-	SlackAnnouncement   = "Slack Announcement"
-	CheckAndAdd         = "Pending PRs/Issues"
-	CheckSummary        = "Check Release Summary"
-	DraftBlogPost       = "Draft Blog Post"
-	CrossPostBlogPost   = "Cross-post Blog Post"
-
-	// Pre-Release
-	CodeFreeze                   = "Code Freeze"
-	CopyBranchProtectionRules    = "Copy branch protection rules"
-	CreateNewLabels              = "Create new labels"
-	UpdateSnapshotOnMain         = "Update SNAPSHOT on main"
-	CreateReleasePR              = "Create Release PR"
-	CreateMilestone              = "Create Milestone"
+	GeneralPrerequisite          = "General"
+	SlackAnnouncement            = "Slack Announcement"
+	CheckAndAdd                  = "Pending PRs/Issues"
+	CheckSummary                 = "Check Release Summary"
+	DraftBlogPost                = "Draft Blog Post"
 	VtopCreateBranch             = "Create vitess-operator release branch"
 	VtopBumpMainVersion          = "Bump version of vitess-operator on main"
-	VtopUpdateGolang             = "Update Go version in vitess-operator"
 	VtopUpdateCompatibilityTable = "Update compatibility table in vitess-operator"
+	CrossPostBlogPost            = "Cross-post Blog Post"
+
+	// Pre-Release
+	CodeFreeze                = "Code Freeze"
+	CopyBranchProtectionRules = "Copy branch protection rules"
+	CreateNewLabels           = "Create new labels"
+	UpdateSnapshotOnMain      = "Update SNAPSHOT on main"
+	CreateReleasePR           = "Create Release PR"
+	CreateMilestone           = "Create Milestone"
+	VtopUpdateGolang          = "Update Go version in vitess-operator"
 
 	// Release
 	MergeReleasePR              = "Merge Release PR"


### PR DESCRIPTION
This PR moves three vtop related steps from pre-release to code freeze. They had nothing to do in the pre-release and are artefacts from the previous release process.

Part of https://github.com/vitessio/vitess-releaser/issues/114