### PR TITLE
Improve vtop release process by creating the Release PR first

### DIFF
--- a/go/interactive/main_menu.go
+++ b/go/interactive/main_menu.go
@@ -90,7 +90,6 @@ func MainScreen(ctx context.Context, state *releaser.State) {
 		release.CloseMilestoneItem(ctx),
 		simpleMenuItem(ctx, "ReleaseArtifacts", releaselogic.CheckArtifacts(state), steps.ReleaseArtifacts, false),
 	)
-	releaseMenu.Sequential = true
 
 	postReleaseMenu := ui.NewMenu(
 		ctx,

--- a/go/interactive/main_menu.go
+++ b/go/interactive/main_menu.go
@@ -88,7 +88,7 @@ func MainScreen(ctx context.Context, state *releaser.State) {
 		dockerImagesItem(ctx),
 		release.CloseMilestoneItem(ctx),
 		simpleMenuItem(ctx, "ReleaseArtifacts", releaselogic.CheckArtifacts(state), steps.ReleaseArtifacts, false),
-		// todo: merge pr
+		release.VtopMergeReleasePRItem(ctx),
 		release.VtopTagReleaseMenuItem(ctx),
 		release.VtopBackToDevModeItem(ctx),
 		release.VtopManualUpdateItem(ctx),

--- a/go/interactive/main_menu.go
+++ b/go/interactive/main_menu.go
@@ -80,7 +80,6 @@ func MainScreen(ctx context.Context, state *releaser.State) {
 		release.TagReleaseItem(ctx),
 		release.JavaReleaseItem(ctx),
 		release.VtopCreateReleasePRMenuItem(ctx),
-		release.VtopManualUpdateItem(ctx),
 		release.ReleaseNotesOnMainItem(ctx),
 		release.BackToDevModeItem(ctx),
 		mergeBlogPostPRMenuItem(ctx),
@@ -89,6 +88,10 @@ func MainScreen(ctx context.Context, state *releaser.State) {
 		dockerImagesItem(ctx),
 		release.CloseMilestoneItem(ctx),
 		simpleMenuItem(ctx, "ReleaseArtifacts", releaselogic.CheckArtifacts(state), steps.ReleaseArtifacts, false),
+		// todo: merge pr
+		release.VtopTagReleaseMenuItem(ctx),
+		// todo: back to dev mode
+		release.VtopManualUpdateItem(ctx),
 	)
 
 	postReleaseMenu := ui.NewMenu(

--- a/go/interactive/main_menu.go
+++ b/go/interactive/main_menu.go
@@ -90,7 +90,7 @@ func MainScreen(ctx context.Context, state *releaser.State) {
 		simpleMenuItem(ctx, "ReleaseArtifacts", releaselogic.CheckArtifacts(state), steps.ReleaseArtifacts, false),
 		// todo: merge pr
 		release.VtopTagReleaseMenuItem(ctx),
-		// todo: back to dev mode
+		release.VtopBackToDevModeItem(ctx),
 		release.VtopManualUpdateItem(ctx),
 	)
 

--- a/go/interactive/release/vtop_back_to_dev.go
+++ b/go/interactive/release/vtop_back_to_dev.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package release
+
+import (
+	"context"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/vitessio/vitess-releaser/go/interactive/ui"
+	"github.com/vitessio/vitess-releaser/go/releaser"
+	"github.com/vitessio/vitess-releaser/go/releaser/release"
+	"github.com/vitessio/vitess-releaser/go/releaser/steps"
+)
+
+func VtopBackToDevModeItem(ctx context.Context) *ui.MenuItem {
+	state := releaser.UnwrapState(ctx)
+	act := vtopBackToDevAct
+	if state.Issue.VtopBackToDevMode.Done {
+		act = nil
+	}
+	return &ui.MenuItem{
+		State:  state,
+		Name:   steps.VtopBackToDev,
+		Act:    act,
+		Update: vtopBackToDevUpdate,
+		IsDone: state.Issue.VtopBackToDevMode.Done,
+		Info:   state.Issue.VtopBackToDevMode.URL,
+
+		Ignore: state.VtOpRelease.Release == "",
+	}
+}
+
+type vtopBackToDevUrl string
+
+func vtopBackToDevUpdate(mi *ui.MenuItem, msg tea.Msg) (*ui.MenuItem, tea.Cmd) {
+	_, ok := msg.(vtopBackToDevUrl)
+	if !ok {
+		return mi, nil
+	}
+
+	mi.IsDone = mi.State.Issue.VtopBackToDevMode.Done
+	mi.Info = mi.State.Issue.VtopBackToDevMode.URL
+	return mi, nil
+}
+
+func vtopBackToDevAct(mi *ui.MenuItem) (*ui.MenuItem, tea.Cmd) {
+	pl, act := release.VtopBackToDev(mi.State)
+	return mi, tea.Batch(func() tea.Msg {
+		return vtopBackToDevUrl(act())
+	}, ui.PushDialog(ui.NewProgressDialog(steps.VtopBackToDev, pl)))
+}

--- a/go/interactive/release/vtop_create_release_pr.go
+++ b/go/interactive/release/vtop_create_release_pr.go
@@ -18,7 +18,6 @@ package release
 
 import (
 	"context"
-	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/vitessio/vitess-releaser/go/interactive/ui"
@@ -39,7 +38,7 @@ func VtopCreateReleasePRMenuItem(ctx context.Context) *ui.MenuItem {
 		Act:    act,
 		Update: vtopCreateReleasePRUpdate,
 		IsDone: state.Issue.VtopCreateReleasePR.Done,
-		Info:   strings.Join(state.Issue.VtopCreateReleasePR.URLs, " | "),
+		Info:   state.Issue.VtopCreateReleasePR.URL,
 
 		Ignore: state.VtOpRelease.Release == "",
 	}
@@ -54,7 +53,7 @@ func vtopCreateReleasePRUpdate(mi *ui.MenuItem, msg tea.Msg) (*ui.MenuItem, tea.
 	}
 
 	mi.IsDone = mi.State.Issue.VtopCreateReleasePR.Done
-	mi.Info = strings.Join(mi.State.Issue.VtopCreateReleasePR.URLs, " | ")
+	mi.Info = mi.State.Issue.VtopCreateReleasePR.URL
 	return mi, nil
 }
 

--- a/go/interactive/release/vtop_merge_release_pr.go
+++ b/go/interactive/release/vtop_merge_release_pr.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package release
+
+import (
+	"context"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/vitessio/vitess-releaser/go/interactive/ui"
+	"github.com/vitessio/vitess-releaser/go/releaser"
+	"github.com/vitessio/vitess-releaser/go/releaser/release"
+	"github.com/vitessio/vitess-releaser/go/releaser/steps"
+)
+
+func VtopMergeReleasePRItem(ctx context.Context) *ui.MenuItem {
+	state := releaser.UnwrapState(ctx)
+	act := vtopMergeReleasePRAct
+	if state.Issue.VtopMergeReleasePR.Done {
+		act = nil
+	}
+
+	info := "Run this step once the Release Pull Request was created."
+	if state.Issue.VtopCreateReleasePR.URL != "" {
+		info = state.Issue.VtopCreateReleasePR.URL
+	}
+
+	return &ui.MenuItem{
+		State:  state,
+		Name:   steps.VtopMergeReleasePR,
+		Act:    act,
+		Update: vtopMergeReleasePRUpdate,
+		IsDone: state.Issue.VtopMergeReleasePR.Done,
+		Info:   info,
+
+		Ignore: state.VtOpRelease.Release == "",
+	}
+}
+
+type vtopMergeReleasePRUrl string
+
+func vtopMergeReleasePRUpdate(mi *ui.MenuItem, msg tea.Msg) (*ui.MenuItem, tea.Cmd) {
+	_, ok := msg.(vtopMergeReleasePRUrl)
+	if !ok {
+		return mi, nil
+	}
+
+	mi.IsDone = mi.State.Issue.VtopMergeReleasePR.Done
+	mi.Info = mi.State.Issue.VtopMergeReleasePR.URL
+	return mi, nil
+}
+
+func vtopMergeReleasePRAct(mi *ui.MenuItem) (*ui.MenuItem, tea.Cmd) {
+	if mi.State.Issue.VtopCreateReleasePR.URL == "" {
+		return mi, nil
+	}
+
+	pl, act := release.VtopMergeReleasePR(mi.State)
+	return mi, tea.Batch(func() tea.Msg {
+		return vtopMergeReleasePRUrl(act())
+	}, ui.PushDialog(ui.NewProgressDialog(steps.VtopMergeReleasePR, pl)))
+}

--- a/go/interactive/release/vtop_tag_release.go
+++ b/go/interactive/release/vtop_tag_release.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package release
+
+import (
+	"context"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/vitessio/vitess-releaser/go/interactive/ui"
+	"github.com/vitessio/vitess-releaser/go/releaser"
+	"github.com/vitessio/vitess-releaser/go/releaser/release"
+	"github.com/vitessio/vitess-releaser/go/releaser/steps"
+)
+
+func VtopTagReleaseMenuItem(ctx context.Context) *ui.MenuItem {
+	state := releaser.UnwrapState(ctx)
+	act := vtopTagReleaseAct
+	if state.Issue.VtopTagRelease.Done {
+		act = nil
+	}
+	return &ui.MenuItem{
+		State:  state,
+		Name:   steps.VtopTagRelease,
+		Act:    act,
+		Update: vtopTagReleaseUpdate,
+		IsDone: state.Issue.VtopTagRelease.Done,
+		Info:   state.Issue.VtopTagRelease.URL,
+
+		Ignore: state.VtOpRelease.Release == "",
+	}
+}
+
+type vtopTagReleaseUrl string
+
+func vtopTagReleaseUpdate(mi *ui.MenuItem, msg tea.Msg) (*ui.MenuItem, tea.Cmd) {
+	_, ok := msg.(vtopTagReleaseUrl)
+	if !ok {
+		return mi, nil
+	}
+
+	mi.IsDone = mi.State.Issue.VtopTagRelease.Done
+	mi.Info = mi.State.Issue.VtopTagRelease.URL
+	return mi, nil
+}
+
+func vtopTagReleaseAct(mi *ui.MenuItem) (*ui.MenuItem, tea.Cmd) {
+	pl, act := release.VtopTagRelease(mi.State)
+	return mi, tea.Batch(func() tea.Msg {
+		return vtopTagReleaseUrl(act())
+	}, ui.PushDialog(ui.NewProgressDialog(steps.VtopTagRelease, pl)))
+}

--- a/go/releaser/issue.go
+++ b/go/releaser/issue.go
@@ -284,8 +284,8 @@ const (
 {{- end }}
 {{- if .DoVtOp }}
 - [{{fmtStatus .VtopCreateReleasePR.Done}}] Create vitess-operator Release PR.
-{{- range $item := .VtopCreateReleasePR.URLs }}
-  - {{$item}}
+{{- if .VtopCreateReleasePR.URL }}
+  - {{ .VtopCreateReleasePR.URL }}
 {{- end }}
 {{- end }}
 - [{{fmtStatus .ReleaseNotesOnMain.Done}}] Update release notes on main.

--- a/go/releaser/release/vtop_back_to_dev.go
+++ b/go/releaser/release/vtop_back_to_dev.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package release
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/vitessio/vitess-releaser/go/releaser"
+	"github.com/vitessio/vitess-releaser/go/releaser/code_freeze"
+	"github.com/vitessio/vitess-releaser/go/releaser/git"
+	"github.com/vitessio/vitess-releaser/go/releaser/github"
+	"github.com/vitessio/vitess-releaser/go/releaser/logging"
+	"github.com/vitessio/vitess-releaser/go/releaser/utils"
+)
+
+func VtopBackToDev(state *releaser.State) (*logging.ProgressLogging, func() string) {
+	pl := &logging.ProgressLogging{
+		TotalSteps: 8,
+	}
+
+	var done bool
+	var url string
+	return pl, func() string {
+		defer func() {
+			state.Issue.VtopBackToDevMode.Done = done
+			state.Issue.VtopBackToDevMode.URL = url
+			pl.NewStepf("Update Issue %s on GitHub", state.IssueLink)
+			_, fn := state.UploadIssue()
+			issueLink := fn()
+
+			pl.NewStepf("Issue updated, see: %s", issueLink)
+		}()
+
+		state.GoToVtOp()
+		defer state.GoToVitess()
+
+		// 1. Setup of the vtop codebase
+		pl.NewStepf("Fetch from git remote")
+		git.CorrectCleanRepo(state.VtOpRelease.Repo)
+		git.ResetHard(state.VtOpRelease.Remote, state.VtOpRelease.ReleaseBranch)
+
+		// 2. Create temporary branch for the release
+		pl.NewStepf("Create temporary branch from %s", state.VtOpRelease.ReleaseBranch)
+		newBranchName := git.FindNewGeneratedBranch(state.VtOpRelease.Remote, state.VtOpRelease.ReleaseBranch, "back-to-dev")
+
+		releaseNameWithRC := releaser.AddRCToReleaseTitle(state.VtOpRelease.Release, state.Issue.RC)
+		lowerReleaseName := strings.ToLower(releaseNameWithRC)
+
+		// 3. Figure out what is the next vtop release for this branch
+		nextRelease := findNextVtOpVersion(state.VtOpRelease.Release, state.Issue.RC)
+
+		// 4. Back to dev mode and commit
+		pl.NewStepf("Go back to dev mode with version = %s", nextRelease)
+		code_freeze.UpdateVtOpVersionGoFile(nextRelease)
+		noCommit := git.CommitAll(fmt.Sprintf("Go back to dev mode"))
+		if noCommit {
+			done = true
+			pl.TotalSteps -= 3
+			return ""
+		}
+
+		// 5. Push back to dev mode
+		pl.NewStepf("Pushing back to dev mode to %s", newBranchName)
+		git.Push(state.VtOpRelease.Remote, newBranchName)
+
+		// 6. Create the Pull Request
+		pl.NewStepf("Create Pull Request")
+		pr := github.PR{
+			Title:  fmt.Sprintf("[%s] Back to dev mode after the release of `v%s`", state.VtOpRelease.ReleaseBranch, lowerReleaseName),
+			Body:   fmt.Sprintf("This Pull Request updates the %s branch to go back to dev mode after the release of v%s.", state.VtOpRelease.ReleaseBranch, lowerReleaseName),
+			Branch: newBranchName,
+			Base:   state.VtOpRelease.ReleaseBranch,
+			Labels: []github.Label{},
+		}
+		_, url = pr.Create(state.VtOpRelease.Repo)
+		pl.NewStepf("Pull Request created %s", url)
+
+		done = true
+		return url
+	}
+}
+
+func findNextVtOpVersion(version string, rc int) string {
+	if rc > 0 {
+		return version
+	}
+	segments := strings.Split(version, ".")
+	if len(segments) != 3 {
+		utils.BailOut(nil, "expected three segments when looking at the vtop version, got: %s", version)
+	}
+
+	segmentInts := make([]int, 0, len(segments))
+	for _, segment := range segments {
+		v, err := strconv.Atoi(segment)
+		if err != nil {
+			utils.BailOut(err, "failed to convert segment of the vtop version to an int: %s", segment)
+		}
+		segmentInts = append(segmentInts, v)
+	}
+	return fmt.Sprintf("%d.%d.%d", segmentInts[0], segmentInts[1], segmentInts[2]+1)
+}

--- a/go/releaser/release/vtop_create_release_pr.go
+++ b/go/releaser/release/vtop_create_release_pr.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io/fs"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -265,24 +264,4 @@ func vtopTestFiles() []string {
 		utils.BailOut(err, "failed to walk directory %s", root)
 	}
 	return files
-}
-
-func findNextVtOpVersion(version string, rc int) string {
-	if rc > 0 {
-		return version
-	}
-	segments := strings.Split(version, ".")
-	if len(segments) != 3 {
-		utils.BailOut(nil, "expected three segments when looking at the vtop version, got: %s", version)
-	}
-
-	segmentInts := make([]int, 0, len(segments))
-	for _, segment := range segments {
-		v, err := strconv.Atoi(segment)
-		if err != nil {
-			utils.BailOut(err, "failed to convert segment of the vtop version to an int: %s", segment)
-		}
-		segmentInts = append(segmentInts, v)
-	}
-	return fmt.Sprintf("%d.%d.%d", segmentInts[0], segmentInts[1], segmentInts[2]+1)
 }

--- a/go/releaser/release/vtop_create_release_pr.go
+++ b/go/releaser/release/vtop_create_release_pr.go
@@ -152,7 +152,7 @@ func VtopCreateReleasePR(state *releaser.State) (*logging.ProgressLogging, func(
 		// 10. Tag the latest commit
 		gitTag := fmt.Sprintf("v%s", lowerReleaseName)
 		pl.NewStepf("Tag and push %s", gitTag)
-		git.TagAndPush(state.VitessRelease.Remote, gitTag)
+		git.TagAndPush(state.VtOpRelease.Remote, gitTag)
 
 		// 11. Figure out what is the next vtop release for this branch
 		nextRelease := findNextVtOpVersion(state.VtOpRelease.Release, state.Issue.RC)

--- a/go/releaser/release/vtop_manual_update.go
+++ b/go/releaser/release/vtop_manual_update.go
@@ -27,19 +27,10 @@ func VtopManualUpdateMessage(state *releaser.State) []string {
 	var urlVtopReleasePRMsg string
 	var vtopHeadReleaseBranch string
 
-	for _, url := range state.Issue.VtopCreateReleasePR.URLs {
-		// In VtopCreateReleasePR there are usually two links: one to the release page and another to the release PR.
-		// We are trying to find the URL that links to a PR page.
-		if strings.Contains(url, "/pull/") {
-			urlVtopReleasePRMsg = url
-			vtopHeadReleaseBranch = url
-			break
-		}
-	}
 	// The steps in the 'release' section are sequential, it is therefor not possible to not have a release PR.
 	// Unless, there was a bug/issue or the release team manually modified the release issue.
 	// In which case we might fail to find the release PR, and thus defaulting to the following message:
-	if urlVtopReleasePRMsg == "" {
+	if state.Issue.VtopCreateReleasePR.URL == "" {
 		urlVtopReleasePRMsg = fmt.Sprintf("the '%s' release branch by creating a new PR", state.VtOpRelease.ReleaseBranch)
 		vtopHeadReleaseBranch = state.VtOpRelease.ReleaseBranch
 

--- a/go/releaser/release/vtop_manual_update.go
+++ b/go/releaser/release/vtop_manual_update.go
@@ -24,8 +24,8 @@ import (
 )
 
 func VtopManualUpdateMessage(state *releaser.State) []string {
-	var urlVtopReleasePRMsg string
-	var vtopHeadReleaseBranch string
+	urlVtopReleasePRMsg := state.Issue.VtopBackToDevMode.URL
+	vtopHeadReleaseBranch := state.Issue.VtopBackToDevMode.URL
 
 	// The steps in the 'release' section are sequential, it is therefor not possible to not have a release PR.
 	// Unless, there was a bug/issue or the release team manually modified the release issue.

--- a/go/releaser/release/vtop_manual_update.go
+++ b/go/releaser/release/vtop_manual_update.go
@@ -30,10 +30,9 @@ func VtopManualUpdateMessage(state *releaser.State) []string {
 	// The steps in the 'release' section are sequential, it is therefor not possible to not have a release PR.
 	// Unless, there was a bug/issue or the release team manually modified the release issue.
 	// In which case we might fail to find the release PR, and thus defaulting to the following message:
-	if state.Issue.VtopCreateReleasePR.URL == "" {
+	if state.Issue.VtopBackToDevMode.URL == "" {
 		urlVtopReleasePRMsg = fmt.Sprintf("the '%s' release branch by creating a new PR", state.VtOpRelease.ReleaseBranch)
 		vtopHeadReleaseBranch = state.VtOpRelease.ReleaseBranch
-
 	}
 
 	previousVitessRelease := releaser.FindPreviousRelease(state.VitessRelease.Remote, state.VitessRelease.MajorRelease)

--- a/go/releaser/release/vtop_merge_pr.go
+++ b/go/releaser/release/vtop_merge_pr.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package release
+
+import (
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/vitessio/vitess-releaser/go/releaser"
+	"github.com/vitessio/vitess-releaser/go/releaser/github"
+	"github.com/vitessio/vitess-releaser/go/releaser/logging"
+	"github.com/vitessio/vitess-releaser/go/releaser/utils"
+)
+
+func VtopMergeReleasePR(state *releaser.State) (*logging.ProgressLogging, func() string) {
+	pl := &logging.ProgressLogging{
+		TotalSteps: 6,
+	}
+
+	return pl, func() string {
+		state.GoToVtOp()
+		defer state.GoToVitess()
+
+		pl.NewStepf("Resolve Release Pull Request URL")
+		url := state.Issue.VtopCreateReleasePR.URL
+		nb, err := strconv.Atoi(url[strings.LastIndex(url, "/")+1:])
+		if err != nil {
+			utils.BailOut(err, "failed to parse the PR number from GitHub URL: %s", url)
+		}
+
+		pl.NewStepf("Waiting for %s to be merged", url)
+
+		// The vtop release PR is created at the very last minute when the Vitess release just
+		// get released, in this case, CI may not have time to complete before reaching the
+		// 'vitess-operator merge release PR'. If the release team runs this step, but the PR
+		// is not green or ready to be merged yet, then they will be forced to 'kill' the vitess-releaser
+		// process in order to get out of the current step, for this specific situation we are catching
+		// interruption signals to allow the release team to cancel this step if they realize they're not ready.
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt)
+		defer signal.Stop(c)
+		pl.NewStepf("If the PR is not ready, this step may be canceled cleanly by doing 'CMD+C'/'CTRL+C'.")
+
+	outer:
+		for {
+			select {
+			case <-time.After(5 * time.Second):
+				if github.IsPRMerged(state.VtOpRelease.Repo, nb) {
+					break outer
+				}
+			case <-c:
+				pl.TotalSteps -= 2
+				pl.NewStepf("Interruption detected, canceling the step.")
+				return url
+			}
+		}
+
+		pl.NewStepf("Pull Request has been merged")
+		state.Issue.VtopMergeReleasePR.Done = true
+		state.Issue.VtopMergeReleasePR.URL = url
+		pl.NewStepf("Update Issue %s on GitHub", state.IssueLink)
+		_, fn := state.UploadIssue()
+		issueLink := fn()
+
+		pl.NewStepf("Issue updated, see: %s", issueLink)
+		return url
+	}
+}

--- a/go/releaser/release/vtop_tag_release.go
+++ b/go/releaser/release/vtop_tag_release.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package release
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/vitessio/vitess-releaser/go/releaser"
+	"github.com/vitessio/vitess-releaser/go/releaser/git"
+	"github.com/vitessio/vitess-releaser/go/releaser/github"
+	"github.com/vitessio/vitess-releaser/go/releaser/logging"
+)
+
+func VtopTagRelease(state *releaser.State) (*logging.ProgressLogging, func() string) {
+	pl := &logging.ProgressLogging{
+		TotalSteps: 6,
+	}
+
+	return pl, func() string {
+		state.GoToVtOp()
+		defer state.GoToVitess()
+
+		// 1. Setup of the vtop codebase
+		pl.NewStepf("Fetch from git remote")
+		git.CorrectCleanRepo(state.VtOpRelease.Repo)
+		git.ResetHard(state.VtOpRelease.Remote, state.VtOpRelease.ReleaseBranch)
+
+		// 2. Tag the latest commit
+		releaseNameWithRC := releaser.AddRCToReleaseTitle(state.VtOpRelease.Release, state.Issue.RC)
+		lowerReleaseName := strings.ToLower(releaseNameWithRC)
+		gitTag := fmt.Sprintf("v%s", lowerReleaseName)
+		pl.NewStepf("Tag and push %s", gitTag)
+		git.TagAndPush(state.VtOpRelease.Remote, gitTag)
+
+		// 3. Create the release on the GitHub UI
+		pl.NewStepf("Create the release on the GitHub UI")
+		url := github.CreateRelease(
+			state.VtOpRelease.Repo,
+			gitTag,
+			"",
+			state.VtOpRelease.IsLatestRelease && state.Issue.RC == 0,
+			state.Issue.RC > 0,
+		)
+		pl.NewStepf("Done %s", url)
+
+		state.Issue.VtopTagRelease.Done = true
+		state.Issue.VtopTagRelease.URL = url
+		pl.NewStepf("Update Issue %s on GitHub", state.IssueLink)
+		_, fn := state.UploadIssue()
+		issueLink := fn()
+
+		pl.NewStepf("Issue updated, see: %s", issueLink)
+		return url
+	}
+}

--- a/go/releaser/steps/steps.go
+++ b/go/releaser/steps/steps.go
@@ -45,7 +45,6 @@ const (
 	MergeReleasePR              = "Merge Release PR"
 	TagRelease                  = "Tag Release"
 	VtopCreateReleasePR         = "Create vitess-operator release PR"
-	VtopManualUpdate            = "Manual update of vitess-operator tests"
 	JavaRelease                 = "Java Release"
 	ReleaseNotesOnMain          = "Release Notes on main"
 	ReleaseNotesOnReleaseBranch = "Release Notes on release branch"
@@ -57,6 +56,10 @@ const (
 	DockerImages                = "Docker Images"
 	CloseMilestone              = "Close Milestone"
 	ReleaseArtifacts            = "Release Artifacts"
+	VtopMergeReleasePR          = "Merge the vitess-operator Release PR"
+	VtopTagRelease              = "Tag the vitess-operator release"
+	VtopBackToDev               = "Back To Dev Mode vitess-operator"
+	VtopManualUpdate            = "Manual update of vitess-operator tests"
 
 	// Post-Release
 	SlackAnnouncementPost  = "Slack Announcement Post-Release"

--- a/go/releaser/steps/steps.go
+++ b/go/releaser/steps/steps.go
@@ -44,7 +44,7 @@ const (
 	// Release
 	MergeReleasePR              = "Merge Release PR"
 	TagRelease                  = "Tag Release"
-	VtopCreateReleasePR         = "Create vitess-operator release PR"
+	VtopCreateReleasePR         = "Create vitess-operator Release PR"
 	JavaRelease                 = "Java Release"
 	ReleaseNotesOnMain          = "Release Notes on main"
 	ReleaseNotesOnReleaseBranch = "Release Notes on release branch"


### PR DESCRIPTION
This PR is long due, it finally changes the release process of vitess-operator by making sure the Release PR is created first. It breaks down the current `Create vitess-operator release PR` step into multiple steps:
- `Create vitess-operator Release PR`
- `Merge the vitess-operator Release PR` **(new step)**
- `Tag the vitess-operator release` **(new step)**
- `Back To Dev Mode vitess-operator` **(new step)**
- `Manual update of vitess-operator tests`

The first step shown above is now only responsible for creating the Release PR (instead of doing everything that's automated), and the last step was moved from the early stage of the `Release` phase to the very end of the phase.

As we must create the vtop Release PR once the Vitess release is out (they're linked to each other, vtop uses the new vitess tags as a dependency), we run the `merge vtop release PR` step and all the following steps at the very end of the phase so, hopefully, CI has time to run and the release team does not encounter a big bottleneck.

I did an entire 'fake' release on my own fork and everything looked good to me, the issue contains all the links to the PRs that were created during that test: https://github.com/frouioui/vitess/issues/368.