### PR TITLE
Bump to version 1.0.5

### DIFF
--- a/go/cmd/cmd.go
+++ b/go/cmd/cmd.go
@@ -34,7 +34,7 @@ import (
 	"github.com/vitessio/vitess-releaser/go/releaser/utils"
 )
 
-const VERSION = "v1.0.4"
+const VERSION = "v1.0.5"
 
 var (
 	releaseVersion     string


### PR DESCRIPTION
Bumping the main branch to version 1.0.5 after the release of v1.0.4.