### PR TITLE
Update Java command and run it for both RCs and GAs

### DIFF
--- a/go/interactive/release/java.go
+++ b/go/interactive/release/java.go
@@ -34,7 +34,7 @@ func JavaReleaseItem(ctx context.Context) *ui.MenuItem {
 		Act:    javaReleaseAct,
 		Update: javaReleaseUpdate,
 		IsDone: state.Issue.JavaRelease,
-		Ignore: !state.VitessRelease.GA,
+		Ignore: !state.VitessRelease.GA || state.Issue.RC == 0,
 	}
 }
 

--- a/go/releaser/issue.go
+++ b/go/releaser/issue.go
@@ -279,7 +279,7 @@ const (
 {{- if .TagRelease.URL }}
   - {{ .TagRelease.URL }}
 {{- end }}
-{{- if .GA }}
+{{- if or (gt .RC 0) (.GA) }}
 - [{{fmtStatus .JavaRelease}}] Java release.
 {{- end }}
 {{- if .DoVtOp }}


### PR DESCRIPTION
This PR updates the Java release step, we will now run it for both RCs and GAs releases - instead of just GAs. This PR also omit the `-DskipTests` mvn flag for >= v22.0 releases.