### PR TITLE
Add a link to the `create_release.yml` workflow in the release artifacts step

### DIFF
--- a/go/releaser/release/artifacts.go
+++ b/go/releaser/release/artifacts.go
@@ -26,5 +26,7 @@ func CheckArtifacts(state *releaser.State) []string {
 	return []string{
 		fmt.Sprintf("Check that release artifacts were generated: at bottom of https://github.com/vitessio/vitess/releases/tag/%s.", state.GetTag()),
 		"",
+		"The workflow that builds the artifacts can be found here: https://github.com/vitessio/vitess/actions/workflows/create_release.yml",
+		"This workflow must be green.",
 	}
 }


### PR DESCRIPTION
Small update to the "check release artifacts" step, it was cumbersome to find the related workflow that needed to be checked, adding a link will now make the step easier to follow. 