### PR TITLE
Minor improvements ahead of the `v22.0.0` release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vitessio/vitess-releaser
 
-go 1.21.0
+go 1.24.1
 
 require (
 	github.com/charmbracelet/bubbles v0.16.1

--- a/go/interactive/ui/ui.go
+++ b/go/interactive/ui/ui.go
@@ -110,26 +110,24 @@ func (m UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m UI) View() string {
-	_, isMenu := m.Active.(*Menu)
-	if !isMenu {
+	if _, ok := m.Active.(ProgressDialog); ok {
 		return m.Active.View()
 	}
-	title := "Vitess Releaser: 'q' = back, 'enter' = action"
-	width := m.Size.Width
-	if width == 0 {
-		width = 100
-	}
-	lft := bgStyle.Render(title)
-	width -= len(title)
-	s := bgStyle.Copy().Width(width).Align(lipgloss.Right)
-	rgt := fmt.Sprintf("Vitess repo: %s | Vitess release: v%s | Release Date: %s", m.State.VitessRelease.Repo, m.State.VitessRelease.Release, m.State.Issue.Date.Format(time.DateOnly))
-	if m.State.VtOpRelease.Release != "" {
-		rgt = fmt.Sprintf("Vitess repo: %s | Vtop repo: %s | Vitess release: v%s | Vtop release: v%s | Release Date: %s", m.State.VitessRelease.Repo, m.State.VtOpRelease.Repo, m.State.VitessRelease.Release, releaser.AddRCToReleaseTitle(m.State.VtOpRelease.Release, m.State.Issue.RC), m.State.Issue.Date.Format(time.DateOnly))
-	}
-	statusBar := lft + s.Render(rgt)
-	return lipgloss.JoinVertical(
-		lipgloss.Right,
+
+	elems := []string{
 		m.Active.View(),
-		statusBar,
+		"",
+	}
+
+	elems = append(elems, bgStyle.Render("Vitess Releaser: 'q' = back, 'enter' = action"))
+	elems = append(elems, bgStyle.Render(fmt.Sprintf("Vitess repo: %s | Vitess release: v%s", m.State.VitessRelease.Repo, m.State.VitessRelease.Release)))
+	if m.State.VtOpRelease.Release != "" {
+		elems = append(elems, bgStyle.Render(fmt.Sprintf("Vtop repo: %s | Vtop release: v%s", m.State.VtOpRelease.Repo, releaser.AddRCToReleaseTitle(m.State.VtOpRelease.Release, m.State.Issue.RC))))
+	}
+	elems = append(elems, bgStyle.Render(fmt.Sprintf("Release Date: %s", m.State.Issue.Date.Format(time.DateOnly))))
+
+	return lipgloss.JoinVertical(
+		lipgloss.Left,
+		elems...,
 	)
 }

--- a/go/releaser/code_freeze/code_freeze.go
+++ b/go/releaser/code_freeze/code_freeze.go
@@ -140,7 +140,7 @@ func CodeFreeze(state *releaser.State) (*logging.ProgressLogging, func() string)
 			Base:   state.VitessRelease.ReleaseBranch,
 			Labels: []github.Label{{Name: "Component: General"}, {Name: "Type: Release"}},
 		}
-		nb, url = pr.Create(state.VitessRelease.Repo)
+		nb, url = pr.Create(state.IssueLink, state.VitessRelease.Repo)
 		pl.NewStepf("Pull Request created %s", url)
 		waitForPRToBeMerged(nb)
 		done = true

--- a/go/releaser/code_freeze/update_snapshot.go
+++ b/go/releaser/code_freeze/update_snapshot.go
@@ -88,7 +88,7 @@ func UpdateSnapshotOnMain(state *releaser.State) (*logging.ProgressLogging, func
 			Base:   "main",
 			Labels: []github.Label{{Name: "Component: General"}, {Name: "Type: Release"}},
 		}
-		_, url = pr.Create(state.VitessRelease.Repo)
+		_, url = pr.Create(state.IssueLink, state.VitessRelease.Repo)
 		pl.NewStepf("Pull Request created %s", url)
 		done = true
 		return ""

--- a/go/releaser/code_freeze/vtop_bump_version_on_main.go
+++ b/go/releaser/code_freeze/vtop_bump_version_on_main.go
@@ -107,7 +107,7 @@ func VtopBumpMainVersion(state *releaser.State) (*logging.ProgressLogging, func(
 				Base:   "main",
 				Labels: []github.Label{},
 			}
-			_, url = pr.Create(state.VtOpRelease.Repo)
+			_, url = pr.Create(state.IssueLink, state.VtOpRelease.Repo)
 			pl.NewStepf("Pull Request created %s", url)
 		} else {
 			pl.TotalSteps -= 2

--- a/go/releaser/github/pr.go
+++ b/go/releaser/github/pr.go
@@ -46,11 +46,14 @@ type PR struct {
 	Number int     `json:"number"`
 }
 
-func (p *PR) Create(repo string) (nb int, url string) {
+func (p *PR) Create(issueLink string, repo string) (nb int, url string) {
 	var labels []string
 	for _, label := range p.Labels {
 		labels = append(labels, label.Name)
 	}
+
+	p.Body = fmt.Sprintf("%s\n\n> This Pull Request is part of %s", p.Body, issueLink)
+
 	stdOut := execGh(
 		"pr", "create",
 		"--repo", repo,

--- a/go/releaser/pre_release/create_release_pr.go
+++ b/go/releaser/pre_release/create_release_pr.go
@@ -133,7 +133,7 @@ func CreateReleasePR(state *releaser.State) (*logging.ProgressLogging, func() st
 			Base:   state.VitessRelease.ReleaseBranch,
 			Labels: []github.Label{{Name: "Component: General"}, {Name: "Type: Release"}, {Name: "Do Not Merge"}},
 		}
-		_, url = pr.Create(state.VitessRelease.Repo)
+		_, url = pr.Create(state.IssueLink, state.VitessRelease.Repo)
 		pl.NewStepf("Pull Request created %s", url)
 		done = true
 		return url

--- a/go/releaser/pre_release/vtop_update_golang.go
+++ b/go/releaser/pre_release/vtop_update_golang.go
@@ -120,7 +120,7 @@ func VtopUpdateGolang(state *releaser.State) (*logging.ProgressLogging, func() s
 			Branch: newBranchName,
 			Base:   state.VtOpRelease.ReleaseBranch,
 		}
-		_, url = pr.Create(state.VtOpRelease.Repo)
+		_, url = pr.Create(state.IssueLink, state.VtOpRelease.Repo)
 		pl.NewStepf("Pull Request created %s", url)
 		done = true
 		return url

--- a/go/releaser/release/back_to_dev.go
+++ b/go/releaser/release/back_to_dev.go
@@ -95,7 +95,7 @@ func BackToDevModeOnBranch(state *releaser.State, itemToUpdate *releaser.ItemWit
 			Base:   branch,
 			Labels: []github.Label{{Name: "Component: General"}, {Name: "Type: Release"}},
 		}
-		_, url = pr.Create(state.VitessRelease.Repo)
+		_, url = pr.Create(state.IssueLink, state.VitessRelease.Repo)
 		pl.NewStepf("Pull Request created %s", url)
 		done = true
 		return ""

--- a/go/releaser/release/copy_release_notes.go
+++ b/go/releaser/release/copy_release_notes.go
@@ -85,7 +85,7 @@ func CopyReleaseNotesToBranch(state *releaser.State, itemToUpdate *releaser.Item
 			Base:   branch,
 			Labels: []github.Label{{Name: "Component: General"}, {Name: "Type: Release"}},
 		}
-		_, url = pr.Create(state.VitessRelease.Repo)
+		_, url = pr.Create(state.IssueLink, state.VitessRelease.Repo)
 		pl.NewStepf("Pull Request created %s", url)
 		done = true
 		return url

--- a/go/releaser/release/docker.go
+++ b/go/releaser/release/docker.go
@@ -18,8 +18,9 @@ package release
 
 import (
 	"fmt"
-	"github.com/vitessio/vitess-releaser/go/releaser"
 	"strings"
+
+	"github.com/vitessio/vitess-releaser/go/releaser"
 )
 
 func CheckDockerMessage(state *releaser.State) []string {
@@ -45,7 +46,7 @@ func CheckDockerMessage(state *releaser.State) []string {
 		msg = append(msg, fmt.Sprintf("\t- https://github.com/%s/actions/workflows/docker_build_images.yml", repo))
 	} else {
 		// this links to the newer GitHub Actions workflow that was introduced in v21 by https://github.com/vitessio/vitess/pull/16339
-		msg = append(msg, fmt.Sprintf("\t- https://github.com/%s/vitess/actions/workflows/build_docker_images.yml", repo))
+		msg = append(msg, fmt.Sprintf("\t- https://github.com/%s/actions/workflows/build_docker_images.yml", repo))
 		msg = append(msg, fmt.Sprintf("\nCheck that the vttestserver image is pushed at https://hub.docker.com/r/vitess/vttestserver/tags?name=%s.", release))
 	}
 

--- a/go/releaser/release/vtop_back_to_dev.go
+++ b/go/releaser/release/vtop_back_to_dev.go
@@ -88,7 +88,7 @@ func VtopBackToDev(state *releaser.State) (*logging.ProgressLogging, func() stri
 			Base:   state.VtOpRelease.ReleaseBranch,
 			Labels: []github.Label{},
 		}
-		_, url = pr.Create(state.VtOpRelease.Repo)
+		_, url = pr.Create(state.IssueLink, state.VtOpRelease.Repo)
 		pl.NewStepf("Pull Request created %s", url)
 
 		done = true

--- a/go/releaser/release/vtop_create_release_pr.go
+++ b/go/releaser/release/vtop_create_release_pr.go
@@ -158,7 +158,7 @@ func VtopCreateReleasePR(state *releaser.State) (*logging.ProgressLogging, func(
 				Base:   state.VtOpRelease.ReleaseBranch,
 				Labels: []github.Label{},
 			}
-			_, url = pr.Create(state.VtOpRelease.Repo)
+			_, url = pr.Create(state.IssueLink, state.VtOpRelease.Repo)
 			pl.NewStepf("Pull Request created %s", url)
 		} else {
 			pl.TotalSteps -= 2


### PR DESCRIPTION
This PR fixes https://github.com/vitessio/vitess-releaser/issues/130 by implementing:
- Helper text (current version, repository, release date) is now visible in more places, even outside of the main menu.
- Go has been upgraded to `go1.24.1`
- The link to see the docker build workflow for `>= v21` has been fixed
- Every Pull Request created by the tool now reference its release issue in the PR's description (e.g. https://github.com/frouioui/vitess/pull/376)