### PR TITLE
Correctly set the number of steps in branch protection rules copy

### DIFF
--- a/go/releaser/code_freeze/copy_branch_protection_rules.go
+++ b/go/releaser/code_freeze/copy_branch_protection_rules.go
@@ -37,7 +37,6 @@ func CopyBranchProtectionRules(state *releaser.State) (*logging.ProgressLogging,
 		}()
 
 		if state.VitessRelease.Repo != "vitessio/vitess" {
-			pl.TotalSteps--
 			pl.NewStepf("Skipping as we are not running on vitessio/vitess.")
 			return ""
 		}


### PR DESCRIPTION
Fixes a small UI bug where the amount of steps was incorrect.