### PR TITLE
Fix milestone JSON parsing for newer gh-milestone versions

### DIFF
--- a/go/releaser/github/milestone.go
+++ b/go/releaser/github/milestone.go
@@ -39,7 +39,14 @@ func GetMilestonesByName(repo, name string) []Milestone {
 		"--state", "all",
 	)
 
-	str = str[strings.Index(str, "]")+1:]
+	// Older versions of the gh-milestone extension print a preamble before the
+	// JSON array, while newer versions print only the JSON. Locate the array by
+	// its opening bracket so we work with both: since we only query the "url"
+	// and "number" fields (which never contain a "["), the last "[" in the
+	// output is always the start of the JSON array.
+	if idx := strings.LastIndex(str, "["); idx >= 0 {
+		str = str[idx:]
+	}
 
 	var ms []Milestone
 


### PR DESCRIPTION
## Problem

Running the releaser fails during milestone creation with:

```
unexpected end of JSON input
failed to parse milestone, got:
```

`GetMilestonesByName` sliced the `gh milestone list` output past the **first** `]` in order to strip a preamble that **older** versions of the `valeriobelli/gh-milestone` extension printed before the JSON array.

Newer versions of the extension print only the JSON. As a result, the first `]` is now the array's own closing bracket, so the slice discarded the entire payload and left only whitespace — producing `unexpected end of JSON input`. This broke both the empty (`[]`) and non-empty (`[{…}]`) cases.

## Fix

Locate the JSON array via the **last** `[` instead of slicing past the first `]`. This works with both output formats:

- **New (pure JSON):** `[]` / `[{…}]` → last `[` is at index 0 → whole string parses.
- **Old (preamble before JSON):** `…preamble…\n[{…}]` → last `[` is the array opener → preamble dropped.

This is safe because the query only requests the `url` and `number` fields, neither of which can contain a `[`, so the only `[` in the payload is the array opener.

Since the README installs the extension unpinned (`gh extension install valeriobelli/gh-milestone`), supporting both formats is preferable to assuming a single version.

## Testing

Verified all four combinations (old/new format × empty/match) parse correctly with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)